### PR TITLE
Add FetchContent-based GTest and simplify tests build

### DIFF
--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -12,6 +12,7 @@ target_sources(sentinel_core
         Authenticator.cpp
         DataCache.cpp
         MarketDataCore.cpp
+        MessageParser.hpp
         # Phase 3: Lock-free performance monitoring
         performancemonitor.cpp
         CoinbaseStreamClientFacade.cpp  # 🔥 NEW: LiveOrderBook implementation

--- a/libs/core/MessageParser.hpp
+++ b/libs/core/MessageParser.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <nlohmann/json.hpp>
+#include "tradedata.h"
+
+namespace MessageParser {
+
+inline std::vector<Trade> parseMarketTrades(const std::string& jsonStr) {
+    std::vector<Trade> trades;
+    auto message = nlohmann::json::parse(jsonStr);
+    if (message.contains("events")) {
+        for (const auto& event : message["events"]) {
+            if (event.contains("trades")) {
+                for (const auto& t : event["trades"]) {
+                    Trade trade;
+                    trade.product_id = t.value("product_id", "");
+                    trade.trade_id = t.value("trade_id", "");
+                    trade.price = std::stod(t.value("price", "0"));
+                    trade.size = std::stod(t.value("size", "0"));
+                    std::string side = t.value("side", "");
+                    if (side == "BUY") trade.side = AggressorSide::Buy;
+                    else if (side == "SELL") trade.side = AggressorSide::Sell;
+                    else trade.side = AggressorSide::Unknown;
+                    trade.timestamp = std::chrono::system_clock::now();
+                    trades.push_back(trade);
+                }
+            }
+        }
+    }
+    return trades;
+}
+
+inline OrderBook parseL2Update(const std::string& jsonStr) {
+    auto message = nlohmann::json::parse(jsonStr);
+    OrderBook book;
+    if (message.contains("product_id"))
+        book.product_id = message["product_id"].get<std::string>();
+    book.timestamp = std::chrono::system_clock::now();
+    if (message.contains("updates")) {
+        for (const auto& update : message["updates"]) {
+            std::string side = update.value("side", "");
+            double price = std::stod(update.value("price_level", "0"));
+            double quantity = std::stod(update.value("new_quantity", "0"));
+            OrderBookLevel level{price, quantity};
+            if (side == "bid") book.bids.push_back(level);
+            else if (side == "offer" || side == "ask") book.asks.push_back(level);
+        }
+    }
+    return book;
+}
+
+} // namespace MessageParser

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,34 +1,60 @@
 # =============================================================================
 # SENTINEL TESTS - CMakeLists.txt
-# Organized test suite for the revolutionary refactored architecture
+# Defines test executables and links them against GTest and the core library.
 # =============================================================================
 
 cmake_minimum_required(VERSION 3.22)
 
-# Test executables with proper include directories
-add_executable(test_comprehensive test_comprehensive.cpp)
-target_link_libraries(test_comprehensive PRIVATE sentinel_core)
-target_include_directories(test_comprehensive PRIVATE ${CMAKE_SOURCE_DIR})
+include(FetchContent)
+# Fetch GoogleTest at configure time
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+)
+FetchContent_MakeAvailable(googletest)
 
-add_executable(test_datacache test_datacache.cpp)
-target_link_libraries(test_datacache PRIVATE sentinel_core)
-target_include_directories(test_datacache PRIVATE ${CMAKE_SOURCE_DIR})
+# This allows CTest to discover and run the tests defined here.
+enable_testing()
 
-add_executable(test_facade test_facade.cpp)
-target_link_libraries(test_facade PRIVATE sentinel_core)
-target_include_directories(test_facade PRIVATE ${CMAKE_SOURCE_DIR})
+# Set the C++ standard for all test targets in this file.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Set C++17 standard for all tests
-set_property(TARGET test_comprehensive PROPERTY CXX_STANDARD 17)
-set_property(TARGET test_datacache PROPERTY CXX_STANDARD 17)
-set_property(TARGET test_facade PROPERTY CXX_STANDARD 17)
+# -----------------------------------------------------------------------------
+# Test Target: test_messageparser
+# A standalone unit test for the JSON parser. It has no Qt dependencies.
+# -----------------------------------------------------------------------------
+add_executable(test_messageparser test_messageparser.cpp)
 
-# Add test descriptions
-set_target_properties(test_comprehensive PROPERTIES DESCRIPTION "Phase 6 comprehensive test suite")
-set_target_properties(test_datacache PROPERTIES DESCRIPTION "Phase 3 DataCache validation tests")
-set_target_properties(test_facade PROPERTIES DESCRIPTION "Phase 5 Facade pattern tests")
+target_link_libraries(test_messageparser PRIVATE
+  sentinel_core       # Assumes your core library target is named this
+  GTest::gtest_main
+)
+
+add_test(NAME MessageParserTests COMMAND test_messageparser)
+
+
+# -----------------------------------------------------------------------------
+# Test Target: test_rendering_performance
+# The benchmark test, which requires Qt libraries.
+# -----------------------------------------------------------------------------
+add_executable(test_rendering_performance test_rendering_performance.cpp)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets Charts)
+
+# Link against the GUI library and Qt
+target_link_libraries(test_rendering_performance PRIVATE
+  sentinel_core
+  sentinel_gui_lib        # GUI library target
+  GTest::gtest_main
+  Qt6::Widgets
+  Qt6::Charts
+)
+
+add_test(NAME RenderingPerformanceTest COMMAND test_rendering_performance)
+
+# You can add more test executables here as you create them...
+# add_executable(test_authenticator test_authenticator.cpp)
+# ...
 
 message(STATUS "✅ Sentinel test suite configured successfully!")
-message(STATUS "   - test_comprehensive: Full architectural validation")
-message(STATUS "   - test_datacache: DataCache performance & thread safety")
-message(STATUS "   - test_facade: Facade pattern integration tests") 

--- a/tests/test_coinbaseclient.cpp
+++ b/tests/test_coinbaseclient.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+#include "libs/core/Authenticator.hpp"
+#include "libs/core/DataCache.hpp"
+#include "libs/core/MessageParser.hpp"
+#include <fstream>
+#include <cstdio>
+
+class AuthenticatorTest : public ::testing::Test {
+protected:
+    std::string keyFile{"test_key.json"};
+    void SetUp() override {
+        std::ofstream out(keyFile);
+        out << "{\n  \"key\": \"test-key\",\n  \"secret\": \"-----BEGIN PRIVATE KEY-----\\nMIIE...\n-----END PRIVATE KEY-----\"\n}";
+    }
+    void TearDown() override { std::remove(keyFile.c_str()); }
+};
+
+TEST_F(AuthenticatorTest, LoadApiKeys) {
+    EXPECT_NO_THROW({ Authenticator auth(keyFile); });
+}
+
+TEST_F(AuthenticatorTest, GenerateJwtStructure) {
+    Authenticator auth(keyFile);
+    std::string jwt = auth.createJwt();
+    EXPECT_FALSE(jwt.empty());
+    EXPECT_EQ(std::count(jwt.begin(), jwt.end(), '.'), 2);
+}
+
+TEST(MessageParserTest, ParseMarketTrades) {
+    std::string json = R"({
+        \"events\": [{
+            \"trades\": [{
+                \"product_id\": \"BTC-USD\",
+                \"trade_id\": \"1\",
+                \"price\": \"100.0\",
+                \"size\": \"0.5\",
+                \"side\": \"BUY\"
+            }]
+        }]
+    })";
+    auto trades = MessageParser::parseMarketTrades(json);
+    ASSERT_EQ(trades.size(), 1u);
+    EXPECT_EQ(trades[0].product_id, "BTC-USD");
+    EXPECT_EQ(trades[0].trade_id, "1");
+    EXPECT_DOUBLE_EQ(trades[0].price, 100.0);
+    EXPECT_DOUBLE_EQ(trades[0].size, 0.5);
+    EXPECT_EQ(trades[0].side, AggressorSide::Buy);
+}
+
+TEST(MessageParserTest, ParseL2Update) {
+    std::string json = R"({
+        \"product_id\": \"BTC-USD\",
+        \"updates\": [
+            {\"side\": \"bid\", \"price_level\": \"100.0\", \"new_quantity\": \"2\"},
+            {\"side\": \"offer\", \"price_level\": \"101.0\", \"new_quantity\": \"3\"}
+        ]
+    })";
+    auto book = MessageParser::parseL2Update(json);
+    EXPECT_EQ(book.product_id, "BTC-USD");
+    ASSERT_EQ(book.bids.size(), 1u);
+    ASSERT_EQ(book.asks.size(), 1u);
+    EXPECT_DOUBLE_EQ(book.bids[0].price, 100.0);
+    EXPECT_DOUBLE_EQ(book.bids[0].size, 2.0);
+    EXPECT_DOUBLE_EQ(book.asks[0].price, 101.0);
+    EXPECT_DOUBLE_EQ(book.asks[0].size, 3.0);
+}
+
+class DataCacheTest : public ::testing::Test {
+protected:
+    DataCache cache;
+};
+
+TEST_F(DataCacheTest, RecentTrades) {
+    Trade t1{std::chrono::system_clock::now(), "BTC-USD", "1", AggressorSide::Buy, 100.0, 0.1};
+    Trade t2{std::chrono::system_clock::now(), "BTC-USD", "2", AggressorSide::Sell, 101.0, 0.2};
+    cache.addTrade(t1);
+    cache.addTrade(t2);
+    auto trades = cache.recentTrades("BTC-USD");
+    ASSERT_EQ(trades.size(), 2u);
+    EXPECT_EQ(trades[0].trade_id, "1");
+    EXPECT_EQ(trades[1].trade_id, "2");
+}
+
+TEST_F(DataCacheTest, LiveOrderBook) {
+    OrderBook snapshot;
+    snapshot.product_id = "BTC-USD";
+    snapshot.bids.push_back({100.0, 1.0});
+    snapshot.asks.push_back({101.0, 1.0});
+    snapshot.timestamp = std::chrono::system_clock::now();
+
+    cache.initializeLiveOrderBook("BTC-USD", snapshot);
+    cache.updateLiveOrderBook("BTC-USD", "bid", 100.0, 2.0);
+    cache.updateLiveOrderBook("BTC-USD", "offer", 101.0, 0.0); // remove ask
+
+    auto book = cache.getLiveOrderBook("BTC-USD");
+    ASSERT_EQ(book.bids.size(), 1u);
+    EXPECT_DOUBLE_EQ(book.bids[0].size, 2.0);
+    EXPECT_TRUE(book.asks.empty());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tests/test_messageparser.cpp
+++ b/tests/test_messageparser.cpp
@@ -1,0 +1,92 @@
+// =============================================================================
+// MessageParser Unit Tests
+// Validates JSON parsing of market trades and level 2 updates
+// =============================================================================
+
+#include <gtest/gtest.h>
+#include "libs/core/MessageParser.hpp"
+
+// Fixture not required as functions are stateless, but we use namespace alias
+namespace MP = MessageParser;
+
+// -----------------------------------------------------------------------------
+// ParseValidMarketTrades_ReturnsCorrectData
+// -----------------------------------------------------------------------------
+TEST(MessageParserTest, ParseValidMarketTrades_ReturnsCorrectData) {
+    const std::string json = R"({
+        "events": [{
+            "trades": [{
+                "product_id": "BTC-USD",
+                "trade_id": "1",
+                "price": "100.0",
+                "size": "0.5",
+                "side": "BUY"
+            }]
+        }]
+    })";
+
+    auto trades = MP::parseMarketTrades(json);
+    ASSERT_EQ(trades.size(), 1u);
+    const Trade& t = trades.front();
+    EXPECT_EQ(t.product_id, "BTC-USD");
+    EXPECT_EQ(t.trade_id, "1");
+    EXPECT_DOUBLE_EQ(t.price, 100.0);
+    EXPECT_DOUBLE_EQ(t.size, 0.5);
+    EXPECT_EQ(t.side, AggressorSide::Buy);
+}
+
+// -----------------------------------------------------------------------------
+// ParseMarketTrades_EmptyEvents_ReturnsEmptyVector
+// -----------------------------------------------------------------------------
+TEST(MessageParserTest, ParseMarketTrades_EmptyEvents_ReturnsEmptyVector) {
+    const std::string json = R"({ "events": [] })";
+    auto trades = MP::parseMarketTrades(json);
+    EXPECT_TRUE(trades.empty());
+}
+
+// -----------------------------------------------------------------------------
+// ParseMarketTrades_InvalidJson_Throws
+// -----------------------------------------------------------------------------
+TEST(MessageParserTest, ParseMarketTrades_InvalidJson_Throws) {
+    const std::string json = "{ invalid json";
+    EXPECT_THROW({ MP::parseMarketTrades(json); }, nlohmann::json::parse_error);
+}
+
+// -----------------------------------------------------------------------------
+// ParseValidL2Update_ReturnsExpectedBook
+// -----------------------------------------------------------------------------
+TEST(MessageParserTest, ParseValidL2Update_ReturnsExpectedBook) {
+    const std::string json = R"({
+        "product_id": "ETH-USD",
+        "updates": [
+            { "side": "bid", "price_level": "100.0", "new_quantity": "2" },
+            { "side": "offer", "price_level": "101.0", "new_quantity": "3" }
+        ]
+    })";
+
+    auto book = MP::parseL2Update(json);
+    EXPECT_EQ(book.product_id, "ETH-USD");
+    ASSERT_EQ(book.bids.size(), 1u);
+    ASSERT_EQ(book.asks.size(), 1u);
+    EXPECT_DOUBLE_EQ(book.bids.front().price, 100.0);
+    EXPECT_DOUBLE_EQ(book.bids.front().size, 2.0);
+    EXPECT_DOUBLE_EQ(book.asks.front().price, 101.0);
+    EXPECT_DOUBLE_EQ(book.asks.front().size, 3.0);
+}
+
+// -----------------------------------------------------------------------------
+// ParseL2Update_EmptyUpdates_ReturnsEmptyBook
+// -----------------------------------------------------------------------------
+TEST(MessageParserTest, ParseL2Update_EmptyUpdates_ReturnsEmptyBook) {
+    const std::string json = R"({ "product_id": "ETH-USD", "updates": [] })";
+    auto book = MP::parseL2Update(json);
+    EXPECT_EQ(book.product_id, "ETH-USD");
+    EXPECT_TRUE(book.bids.empty());
+    EXPECT_TRUE(book.asks.empty());
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+

--- a/tests/test_rendering_performance.cpp
+++ b/tests/test_rendering_performance.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+#include <QApplication>
+#include <QElapsedTimer>
+#include "libs/gui/tradechartwidget.h"
+#include "libs/gui/gpuchartwidget.h"
+#include "libs/core/tradedata.h"
+
+static const int NUM_TRADES = 100000;
+
+class RenderingBenchmark : public ::testing::Test {
+protected:
+    int argc = 0;
+    char* argv[1] = {nullptr};
+    std::unique_ptr<QApplication> app;
+    void SetUp() override {
+        app = std::make_unique<QApplication>(argc, argv);
+    }
+};
+
+TEST_F(RenderingBenchmark, QPainterBaseline) {
+    TradeChartWidget widget;
+    widget.setSymbol("BTC-USD");
+    QElapsedTimer timer;
+    timer.start();
+    for (int i = 0; i < NUM_TRADES; ++i) {
+        Trade t{std::chrono::system_clock::now(), "BTC-USD", std::to_string(i), AggressorSide::Buy, 100.0 + i*0.01, 0.1};
+        widget.addTrade(t);
+        if (i % 1000 == 0)
+            QCoreApplication::processEvents();
+    }
+    qint64 elapsed = timer.elapsed();
+    qInfo() << "[Benchmark] QPainter Total Time for" << NUM_TRADES << "trades:" << elapsed << "ms";
+}
+
+TEST_F(RenderingBenchmark, GPURenderer) {
+    GPUChartWidget widget;
+    QElapsedTimer timer;
+    timer.start();
+    for (int i = 0; i < NUM_TRADES; ++i) {
+        Trade t{std::chrono::system_clock::now(), "BTC-USD", std::to_string(i), AggressorSide::Buy, 100.0 + i*0.01, 0.1};
+        widget.onTradeReceived(t);
+    }
+    qint64 elapsed = timer.elapsed();
+    qInfo() << "[Benchmark] GPUChartWidget Total Time for" << NUM_TRADES << "trades:" << elapsed << "ms";
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- refactor `tests/CMakeLists.txt` to use FetchContent for GoogleTest
- define only the unit and benchmark test targets following the new convention

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(failed: could not find vcpkg toolchain)*
- `g++ -std=c++17 tests/test_messageparser.cpp libs/core/Authenticator.cpp libs/core/DataCache.cpp -I. -Ilibs/core -pthread -lgtest -lgtest_main -o test_messageparser_manual` *(failed: missing jwt-cpp)*

------
https://chatgpt.com/codex/tasks/task_e_685e35712650832caa0019dd1945aada