### PR TITLE
Add timing instrumentation to data pipeline hot paths

### DIFF
--- a/docs/refactors/data_pipeline_dod/DOD_refactor.plan.md
+++ b/docs/refactors/data_pipeline_dod/DOD_refactor.plan.md
@@ -87,6 +87,9 @@
  - Log snapshot version / pointer address occasionally to confirm double-buffer behavior.
  - Add optional debug assertions that no writes occur from GUI/render threads into snapshot memory.
 - Possibly wrap the new layout in a tiny debug-only “read-only view” that asserts against mutation in debug builds.
+- Extend timing breadcrumbs beyond `UGR paint` by sampling worker-side hotspots:
+  - Log the 100 ms snapshot timer with bucket drift + duration (`SNAPSHOT TIMER`), highlighting when the carry-forward loop grows long enough to threaten frame cadence.
+  - Time `updateVisibleCells` phases (`VISIBLE CELLS TIMING`) to surface slice fetch, AoS build, and snapshot publication costs independently of render-thread `cacheUs`.
 
 ### Expected Perf Benefits
 

--- a/docs/refactors/data_pipeline_dod/current_bottlenecks.md
+++ b/docs/refactors/data_pipeline_dod/current_bottlenecks.md
@@ -59,3 +59,12 @@ While actual numbers depend on runtime measurements, the logging described above
 | Slice availability | `LTSE RESULT: Found <n> slices` (`libs/gui/render/DataProcessor.cpp:446-450`) | Shows how many slices feed `createCellsFromLiquiditySlice` |
 
 Mapping these logs per frame reveals where CPU budget is spent without speculating on optimizations: heavy `cacheUs` + large slice counts points at ingestion-side work, while elevated `contentUs` + `HEATMAP CHUNKS` vertices highlights GPU upload pressure.
+
+## New Timing Probes (worker thread)
+
+Two additional breadcrumbs measure the worker thread in the same microsecond units as `UGR paint`:
+
+* `SNAPSHOT TIMER: bucketsAdded=… durationUs=…` fires from `captureOrderBookSnapshot` whenever the 100 ms timer carries the latest book forward. A large `bucketsAdded` spike or a multi-millisecond `durationUs` hints at timer drift or mutex contention that could explain occasional missing slices on the 100 ms cadence.
+* `VISIBLE CELLS TIMING: totalUs=… sliceFetchUs=… cellBuildUs=… snapshotUs=…` surfaces how long `updateVisibleCells` spends fetching slices from the LTSE, expanding cells, and copying the AoS snapshot. Comparing `totalUs` against the 16 ms frame budget reveals whether CPU overrun happens before geometry even begins.
+
+These logs run behind throttling (`RenderN`) so they stay lightweight but still provide enough sampling resolution to correlate with the intermittent missing-column reports.

--- a/docs/refactors/data_pipeline_dod/hot_paths.md
+++ b/docs/refactors/data_pipeline_dod/hot_paths.md
@@ -33,6 +33,7 @@ if (viewportChanged || m_lastProcessedTime == 0) {
 * **Iteration count:** `visibleSlices` is whatever the LTE returns for the viewport window; at 100 ms buckets over a 30 s view this is ≈300 slices per frame. The loop is sequential, touching two cache-friendly containers: `std::vector<const LiquidityTimeSlice*> visibleSlices` and `std::unordered_set<SliceTimeRange>`.
 * **Memory accessed:** Only metadata (`startTime_ms`, `endTime_ms`, `dataVersion`) plus each slice passed into `createCellsFromLiquiditySlice`. The `unordered_set` operations read/write 24-byte keys (three int64_t-equivalent fields).
 * **Read/write pattern:** Append-mode loops are read-mostly; writes occur when a new slice appears OR when a slice's `dataVersion` changes (triggering stale cell removal and reprocessing). Processed ranges remain in the hash set until viewport changes, so repeated calls typically short-circuit unless slice data has changed.
+* **Instrumentation:** `VISIBLE CELLS TIMING` logs report `sliceFetchUs`, `cellBuildUs`, and `snapshotUs` alongside the processed slice count. If `cellBuildUs` creeps toward the 16 ms budget while missing columns appear on 100 ms views, the AoS expansion here—not rendering—owns the loss.
 
 ## 2. Slice → Cells Expansion
 
@@ -115,6 +116,7 @@ while (producedKeptCells < keptCells) {
 * **Iteration count:** Each frame handles all visible cells after filtering. Logs show 20 k–30 k cells, so the vertex loop executes that many times, emitting 6 vertices per cell (120 k–180 k vertex struct writes). `cellsPerChunk` caps each chunk at 10 000 cells (60 000 vertices) to stay within ANGLE 16-bit index limits.
 * **Memory accessed:** `batch.cells` is contiguous; the loop touches each `CellInstance` field. Two calls to `CoordinateSystem::worldToScreen` per cell read `Viewport` and simple scalars. Writing into `QSGGeometry` hits a fresh heap buffer (per chunk) sequentially.
 * **Read/write pattern:** Strictly sequential and write-only for the vertex buffer; no random access.
+* **Instrumentation:** `HEATMAP CHUNKS` still captures per-chunk work; combine with `VISIBLE CELLS TIMING` to distinguish ingest pressure from geometry churn.
 
 ## 5. Vertex Chunk Logging
 

--- a/docs/refactors/data_pipeline_dod/pipeline_flow.md
+++ b/docs/refactors/data_pipeline_dod/pipeline_flow.md
@@ -19,6 +19,8 @@ If dense ingestion produces no levels, the same handler:
 ### 1.3 Timer-driven snapshots
 Independent of live updates, `captureOrderBookSnapshot` (`DataProcessor.cpp:149-198`) runs every 100 ms to enforce uniform time buckets. It copies the latest sparse `OrderBook`, stamps `timestamp` to the bucket start, and pushes into the engine for each missed interval. This ensures there is always an entry every 100 ms even if real traffic stalls—see the recorded trace in `liquidity_timeseries_log.txt`, where `NEW SLICE 100ms` entries step monotonically in 100 ms increments.
 
+`SNAPSHOT TIMER` logs now report how many buckets were carried forward and how long the timer path took. When missing columns appear in 100 ms views, correlating `bucketsAdded` and `durationUs` with UI timestamps will confirm whether timer drift or mutex contention starved the LTSE of snapshots.
+
 **Threading:** All ingestion work above runs on the dedicated `DataProcessor` `QThread`. The Qt timer and live-order-book slot execute there, guarding shared state via `m_dataMutex`.
 
 ## 2. LiquidityTimeSeriesEngine Aggregation

--- a/libs/gui/render/DataProcessor.cpp
+++ b/libs/gui/render/DataProcessor.cpp
@@ -157,11 +157,14 @@ void DataProcessor::captureOrderBookSnapshot() {
     Early exits occur if the system is shutting down or if no valid liquidity engine exists.
     */
 
+    const auto snapshotStart = std::chrono::steady_clock::now();
+    int carriedForwardBuckets = 0;
+
     // Early return if shutting down
     if (m_shuttingDown.load()) {
         return;
     }
-    
+
     if (!m_liquidityEngine) return;
     
     std::shared_ptr<const OrderBook> book_copy;
@@ -184,6 +187,13 @@ void DataProcessor::captureOrderBookSnapshot() {
         m_liquidityEngine->addOrderBookSnapshot(ob);
         lastBucket = bucketStart;
         updateVisibleCells();
+        carriedForwardBuckets = 1;
+
+        const auto snapshotEnd = std::chrono::steady_clock::now();
+        const auto snapshotUs = std::chrono::duration_cast<std::chrono::microseconds>(snapshotEnd - snapshotStart).count();
+        sLog_RenderN(10, "SNAPSHOT TIMER: initialized 100ms bucket=" << bucketStart
+                                  << " bucketsAdded=" << carriedForwardBuckets
+                                  << " durationUs=" << snapshotUs);
         return;
     }
 
@@ -193,8 +203,19 @@ void DataProcessor::captureOrderBookSnapshot() {
             ob.timestamp = std::chrono::system_clock::time_point(std::chrono::milliseconds(ts));
             m_liquidityEngine->addOrderBookSnapshot(ob);
             lastBucket = ts;
+            ++carriedForwardBuckets;
         }
         updateVisibleCells();
+    }
+
+    if (carriedForwardBuckets > 0) {
+        const auto snapshotEnd = std::chrono::steady_clock::now();
+        const auto snapshotUs = std::chrono::duration_cast<std::chrono::microseconds>(snapshotEnd - snapshotStart).count();
+
+        sLog_RenderN(10, "SNAPSHOT TIMER: bucketsAdded=" << carriedForwardBuckets
+                                  << " latestBucket=" << lastBucket
+                                  << " durationUs=" << snapshotUs
+                                  << " nowMs=" << nowMs);
     }
 }
 
@@ -416,6 +437,8 @@ void DataProcessor::clearData() {
 }
 
 void DataProcessor::updateVisibleCells() {
+    const auto totalStart = std::chrono::steady_clock::now();
+
     // Early return if shutting down
     if (m_shuttingDown.load()) {
         return;
@@ -457,11 +480,20 @@ void DataProcessor::updateVisibleCells() {
     
     // Get liquidity slices for active timeframe within viewport
     if (m_liquidityEngine) {
+        int64_t sliceFetchUs = 0;
+        int64_t cellBuildUs = 0;
+        int64_t snapshotPublishUs = 0;
+        size_t processedSlices = 0;
+
         qint64 timeStart = m_viewState->getVisibleTimeStart();
         qint64 timeEnd = m_viewState->getVisibleTimeEnd();
         sLog_Render("LTSE QUERY: timeframe=" << activeTimeframe << "ms, window=[" << timeStart << "-" << timeEnd << "]");
-        
+
+        const auto sliceFetchStart = std::chrono::steady_clock::now();
         auto visibleSlices = m_liquidityEngine->getVisibleSlices(activeTimeframe, timeStart, timeEnd);
+        sliceFetchUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                           std::chrono::steady_clock::now() - sliceFetchStart)
+                           .count();
         sLog_Render("LTSE RESULT: Found " << visibleSlices.size() << " slices for rendering");
         
         // Auto-fix viewport only when auto-scroll is enabled; never fight user pan/zoom
@@ -497,7 +529,8 @@ void DataProcessor::updateVisibleCells() {
 
         // Track processed slices and append only new data when viewport is stable
         const size_t beforeSize = m_visibleCells.size();
-        int processedSlices = 0;
+        const auto cellBuildStart = std::chrono::steady_clock::now();
+        processedSlices = 0;
 
         if (viewportChanged || m_lastProcessedTime == 0) {
             // Full rebuild: clear processed time range tracking and process everything
@@ -550,6 +583,10 @@ void DataProcessor::updateVisibleCells() {
         // Do NOT prune off-viewport cells here; retain history so zoom-out can
         // immediately reveal older columns without requiring a recompute.
 
+        cellBuildUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                          std::chrono::steady_clock::now() - cellBuildStart)
+                          .count();
+
         // Changed if: viewport changed, cell count changed, OR any slices were (re)processed
         const bool changed = viewportChanged || (m_visibleCells.size() != beforeSize) || (processedSlices > 0);
 
@@ -564,19 +601,43 @@ void DataProcessor::updateVisibleCells() {
         if (changed) {
             {
                 std::lock_guard<std::mutex> snapLock(m_snapshotMutex);
+                const auto publishStart = std::chrono::steady_clock::now();
                 m_publishedCells = std::make_shared<std::vector<CellInstance>>(m_visibleCells);
+                snapshotPublishUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                                         std::chrono::steady_clock::now() - publishStart)
+                                         .count();
             }
             emit dataUpdated();
         }
+
+        const auto totalEnd = std::chrono::steady_clock::now();
+        const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(totalEnd - totalStart).count();
+
+        sLog_RenderN(5, "VISIBLE CELLS TIMING: totalUs=" << totalUs
+                                << " sliceFetchUs=" << sliceFetchUs
+                                << " cellBuildUs=" << cellBuildUs
+                                << " snapshotUs=" << snapshotPublishUs
+                                << " slices=" << visibleSlices.size()
+                                << " processed=" << processedSlices
+                                << " cells=" << m_visibleCells.size()
+                                << " mode=" << (viewportChanged ? "rebuild" : "append"));
         return; // Avoid duplicate publish below
     }
-    
+
     // Fallback: if no liquidity engine, publish current state (likely empty)
     {
         std::lock_guard<std::mutex> snapLock(m_snapshotMutex);
         m_publishedCells = std::make_shared<std::vector<CellInstance>>(m_visibleCells);
     }
     emit dataUpdated();
+
+    const auto totalEnd = std::chrono::steady_clock::now();
+    const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(totalEnd - totalStart).count();
+
+    sLog_RenderN(5, "VISIBLE CELLS TIMING: totalUs=" << totalUs
+                            << " sliceFetchUs=0 cellBuildUs=0 snapshotUs=0"
+                            << " slices=0 processed=0 cells=" << m_visibleCells.size()
+                            << " mode=fallback");
 }
 
 void DataProcessor::createCellsFromLiquiditySlice(const LiquidityTimeSlice& slice) {


### PR DESCRIPTION
## Summary
- add timing instrumentation to the 100ms snapshot timer and visible cell refresh pipeline to surface worker-side latency and bucket drift
- document the new probes across the data pipeline DOD plan, bottleneck guide, hot path reference, and pipeline flow

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a1352fe20832caaf0da8340c03461)