### PR TITLE
chore(agent): scaffold multi-agent workflow for Codex/Claude/Gemini

### DIFF
--- a/.claude/README.AGENTS.md
+++ b/.claude/README.AGENTS.md
@@ -1,0 +1,8 @@
+# Claude Agent Scaffolding (Additive)
+
+Purpose: This directory provides additive scaffolding for Claude Code CLI agents, skills, and commands.
+
+Notes:
+- All files here are new scaffolding only; do not overwrite existing project files.
+- Repository-wide behavior is governed by AGENTS.md; follow it before acting.
+- Treat these files as placeholders until finalized.

--- a/.claude/agents/core-agent.md
+++ b/.claude/agents/core-agent.md
@@ -1,0 +1,10 @@
+# Core Agent (DRAFT)
+
+Scope:
+- Domain: Core architecture and shared foundations.
+- Boundaries: Operate only within core-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.claude/agents/gui-agent.md
+++ b/.claude/agents/gui-agent.md
@@ -1,0 +1,10 @@
+# GUI Agent (DRAFT)
+
+Scope:
+- Domain: UI/UX and GUI surfaces.
+- Boundaries: Operate only within GUI-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.claude/agents/protocol-agent.md
+++ b/.claude/agents/protocol-agent.md
@@ -1,0 +1,10 @@
+# Protocol Agent (DRAFT)
+
+Scope:
+- Domain: Protocol definitions and communication layers.
+- Boundaries: Operate only within protocol-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.claude/agents/renderer-agent.md
+++ b/.claude/agents/renderer-agent.md
@@ -1,0 +1,10 @@
+# Renderer Agent (DRAFT)
+
+Scope:
+- Domain: Rendering pipeline and visual output.
+- Boundaries: Operate only within renderer-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.claude/agents/reviewer-agent.md
+++ b/.claude/agents/reviewer-agent.md
@@ -1,0 +1,10 @@
+# Reviewer Agent (DRAFT)
+
+Scope:
+- Domain: Reviews, audits, and policy compliance.
+- Boundaries: Operate only within review-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.claude/commands/open_pr.md
+++ b/.claude/commands/open_pr.md
@@ -1,0 +1,3 @@
+# open_pr (Placeholder)
+
+Placeholder – logic to be finalized later.

--- a/.claude/skills/core-refactor/SKILL.md
+++ b/.claude/skills/core-refactor/SKILL.md
@@ -1,0 +1,12 @@
+# core-refactor (Placeholder)
+
+Description:
+- Placeholder skill definition for core-refactor.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with core-refactor responsibilities.

--- a/.claude/skills/gui-qml/SKILL.md
+++ b/.claude/skills/gui-qml/SKILL.md
@@ -1,0 +1,12 @@
+# gui-qml (Placeholder)
+
+Description:
+- Placeholder skill definition for gui-qml.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with gui-qml responsibilities.

--- a/.claude/skills/protocol-server/SKILL.md
+++ b/.claude/skills/protocol-server/SKILL.md
@@ -1,0 +1,12 @@
+# protocol-server (Placeholder)
+
+Description:
+- Placeholder skill definition for protocol-server.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with protocol-server responsibilities.

--- a/.claude/skills/renderer-gpu/SKILL.md
+++ b/.claude/skills/renderer-gpu/SKILL.md
@@ -1,0 +1,12 @@
+# renderer-gpu (Placeholder)
+
+Description:
+- Placeholder skill definition for renderer-gpu.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with renderer-gpu responsibilities.

--- a/.claude/skills/tests-perf/SKILL.md
+++ b/.claude/skills/tests-perf/SKILL.md
@@ -1,0 +1,12 @@
+# tests-perf (Placeholder)
+
+Description:
+- Placeholder skill definition for tests-perf.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with tests-perf responsibilities.

--- a/.codex/README.AGENTS.md
+++ b/.codex/README.AGENTS.md
@@ -1,0 +1,8 @@
+# Codex Agent Scaffolding (Additive)
+
+Purpose: This directory provides additive scaffolding for Codex CLI agents, skills, and commands.
+
+Notes:
+- All files here are new scaffolding only; do not overwrite existing project files.
+- Repository-wide behavior is governed by AGENTS.md; follow it before acting.
+- Treat these files as placeholders until finalized.

--- a/.codex/commands/open_pr.md
+++ b/.codex/commands/open_pr.md
@@ -1,0 +1,3 @@
+# open_pr (Placeholder)
+
+Placeholder – logic to be finalized later.

--- a/.codex/skills/core-refactor/SKILL.md
+++ b/.codex/skills/core-refactor/SKILL.md
@@ -1,0 +1,12 @@
+# core-refactor (Placeholder)
+
+Description:
+- Placeholder skill definition for core-refactor.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with core-refactor responsibilities.

--- a/.codex/skills/gui-qml/SKILL.md
+++ b/.codex/skills/gui-qml/SKILL.md
@@ -1,0 +1,12 @@
+# gui-qml (Placeholder)
+
+Description:
+- Placeholder skill definition for gui-qml.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with gui-qml responsibilities.

--- a/.codex/skills/protocol-server/SKILL.md
+++ b/.codex/skills/protocol-server/SKILL.md
@@ -1,0 +1,12 @@
+# protocol-server (Placeholder)
+
+Description:
+- Placeholder skill definition for protocol-server.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with protocol-server responsibilities.

--- a/.codex/skills/renderer-gpu/SKILL.md
+++ b/.codex/skills/renderer-gpu/SKILL.md
@@ -1,0 +1,12 @@
+# renderer-gpu (Placeholder)
+
+Description:
+- Placeholder skill definition for renderer-gpu.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with renderer-gpu responsibilities.

--- a/.codex/skills/tests-perf/SKILL.md
+++ b/.codex/skills/tests-perf/SKILL.md
@@ -1,0 +1,12 @@
+# tests-perf (Placeholder)
+
+Description:
+- Placeholder skill definition for tests-perf.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with tests-perf responsibilities.

--- a/.gemini/README.AGENTS.md
+++ b/.gemini/README.AGENTS.md
@@ -1,0 +1,8 @@
+# Gemini Agent Scaffolding (Additive)
+
+Purpose: This directory provides additive scaffolding for Gemini CLI agents, skills, and commands.
+
+Notes:
+- All files here are new scaffolding only; do not overwrite existing project files.
+- Repository-wide behavior is governed by AGENTS.md; follow it before acting.
+- Treat these files as placeholders until finalized.

--- a/.gemini/agents/core-agent.md
+++ b/.gemini/agents/core-agent.md
@@ -1,0 +1,10 @@
+# Core Agent (DRAFT)
+
+Scope:
+- Domain: Core architecture and shared foundations.
+- Boundaries: Operate only within core-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.gemini/agents/gui-agent.md
+++ b/.gemini/agents/gui-agent.md
@@ -1,0 +1,10 @@
+# GUI Agent (DRAFT)
+
+Scope:
+- Domain: UI/UX and GUI surfaces.
+- Boundaries: Operate only within GUI-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.gemini/agents/orchestrator-agent.md
+++ b/.gemini/agents/orchestrator-agent.md
@@ -1,0 +1,10 @@
+# Orchestrator Agent (DRAFT)
+
+Scope:
+- Domain: Cross-agent coordination and task orchestration.
+- Boundaries: Operate only within orchestration-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.gemini/agents/protocol-agent.md
+++ b/.gemini/agents/protocol-agent.md
@@ -1,0 +1,10 @@
+# Protocol Agent (DRAFT)
+
+Scope:
+- Domain: Protocol definitions and communication layers.
+- Boundaries: Operate only within protocol-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.gemini/agents/renderer-agent.md
+++ b/.gemini/agents/renderer-agent.md
@@ -1,0 +1,10 @@
+# Renderer Agent (DRAFT)
+
+Scope:
+- Domain: Rendering pipeline and visual output.
+- Boundaries: Operate only within renderer-scoped files explicitly assigned by the coordinator.
+
+Rules:
+- Follow AGENTS.md at all times.
+- DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN.
+- If a required file is outside scope, request reassignment.

--- a/.gemini/commands/open_pr.toml
+++ b/.gemini/commands/open_pr.toml
@@ -1,0 +1,2 @@
+# open_pr (Placeholder)
+# Placeholder – logic to be finalized later.

--- a/.gemini/commands/run_tests.toml
+++ b/.gemini/commands/run_tests.toml
@@ -1,0 +1,2 @@
+# run_tests (Placeholder)
+# Placeholder – logic to be finalized later.

--- a/.gemini/skills/core-refactor/SKILL.md
+++ b/.gemini/skills/core-refactor/SKILL.md
@@ -1,0 +1,12 @@
+# core-refactor (Placeholder)
+
+Description:
+- Placeholder skill definition for core-refactor.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with core-refactor responsibilities.

--- a/.gemini/skills/gui-qml/SKILL.md
+++ b/.gemini/skills/gui-qml/SKILL.md
@@ -1,0 +1,12 @@
+# gui-qml (Placeholder)
+
+Description:
+- Placeholder skill definition for gui-qml.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with gui-qml responsibilities.

--- a/.gemini/skills/protocol-server/SKILL.md
+++ b/.gemini/skills/protocol-server/SKILL.md
@@ -1,0 +1,12 @@
+# protocol-server (Placeholder)
+
+Description:
+- Placeholder skill definition for protocol-server.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with protocol-server responsibilities.

--- a/.gemini/skills/renderer-gpu/SKILL.md
+++ b/.gemini/skills/renderer-gpu/SKILL.md
@@ -1,0 +1,12 @@
+# renderer-gpu (Placeholder)
+
+Description:
+- Placeholder skill definition for renderer-gpu.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with renderer-gpu responsibilities.

--- a/.gemini/skills/tests-perf/SKILL.md
+++ b/.gemini/skills/tests-perf/SKILL.md
@@ -1,0 +1,12 @@
+# tests-perf (Placeholder)
+
+Description:
+- Placeholder skill definition for tests-perf.
+
+Rules:
+- Follow AGENTS.md and any scoped instructions.
+- Keep changes within the assigned domain.
+- Prefer additive changes; do not overwrite existing files.
+
+When to use this skill:
+- Use when tasks align with tests-perf responsibilities.


### PR DESCRIPTION
### Motivation
- Provide additive scaffolding to introduce a multi-agent workflow for Codex CLI, Claude Code CLI, and Gemini CLI without changing existing source files.
- Ensure agent prompts and skill placeholders explicitly reference repository policy in `AGENTS.md` and enforce scope boundaries.
- Create a clear, non-functional starting point for future agent, skill, and command implementations while preserving current project state.

### Description
- Add top-level agent scaffolding directories and README markers: `.codex/`, `.claude/`, and `.gemini/` with `README.AGENTS.md` files describing purpose and that `AGENTS.md` governs behavior.
- Add draft agent system prompt files for Claude and Gemini (e.g. `.claude/agents/*-agent.md`, `.gemini/agents/*-agent.md`) that define scope boundaries and include the rule `DO NOT MODIFY FILES OUTSIDE YOUR DOMAIN`.
- Add SKILL.md placeholders under each agent family for `core-refactor`, `gui-qml`, `renderer-gpu`, `protocol-server`, and `tests-perf` with a short description, `Rules`, and `When to use this skill` sections.
- Add non-functional command placeholders: `.codex/commands/open_pr.md`, `.claude/commands/open_pr.md`, `.gemini/commands/open_pr.toml`, and `.gemini/commands/run_tests.toml` marked `Placeholder – logic to be finalized later`.
- Commit performed on branch `agent-workflow-scaffold` with message `chore(agent): scaffold multi-agent workflow (additive only)`, and `.claude` files were force-added because that directory is gitignored.

### Testing
- No automated tests were run since these are scaffolding-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a6f331270832c926b29f809567a2e)