### PR TITLE
Adopt MSDF heatmap labels and add liquidity mode toggle

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -45,8 +45,6 @@ Each feature is a self-contained block. Use this template:
 **Updated:** 2026-01-30
 
 #### Now
-- [ ] Swap GlyphAtlas -> MsdfAtlas and HeatmapGlyphNode -> MsdfGlyphNode in UnifiedGridRenderer
-- [ ] MSDF label UVs: use full cell UVs (cell + padding), keep linear filtering, single atlas size
 - [ ] Label geo cache: cache per-column quads; rebuild only when column/viewport/thresholds change
 - [ ] Thresholds: store raw liquidity/intensity per cell so past columns can be re-evaluated
 
@@ -57,10 +55,12 @@ _(empty)_
 - [ ] Wire MSDF atlas cache into label path (load from disk on startup, upload once)
 
 #### Done
-_(nothing yet)_
+- [x] Swap GlyphAtlas -> MsdfAtlas and HeatmapGlyphNode -> MsdfGlyphNode in UnifiedGridRenderer (2026-01-30)
+- [x] MSDF label UVs: use full cell UVs (cell + padding), keep linear filtering, single atlas size (2026-01-30)
 
 #### Session log
 - **2026-01-30** — MSDF Lab text looks correct; heatmap labels still bitmap. Next: wire MSDF into heatmap labels, then label-geometry cache.
+- **2026-01-30** — Swapped heatmap labels to MSDF atlas/nodes and padded UVs. Next: add label-geometry cache + threshold reevaluation.
 
 ---
 

--- a/libs/gui/MainWindowGpu.cpp
+++ b/libs/gui/MainWindowGpu.cpp
@@ -177,6 +177,13 @@ void MainWindowGPU::setupUI() {
                 renderer->setProperty("heatmapLiquidityThreshold", value);
             }
         });
+        connect(m_heatmapDock->toolbar(), &TopToolbar::liquidityLabelModeChanged, this, [this](int mode) {
+            if (!m_qmlController) return;
+            auto* renderer = m_qmlController->getUnifiedGridRenderer();
+            if (renderer) {
+                renderer->setProperty("liquidityLabelMode", mode);
+            }
+        });
         connect(m_heatmapDock->toolbar(), &TopToolbar::subscribeRequested, this, &MainWindowGPU::onSubscribe);
         connect(m_heatmapDock->toolbar(), &TopToolbar::settingsRequested, this, [this]() {
             if (!m_qmlController) return;

--- a/libs/gui/UnifiedGridRenderer.cpp
+++ b/libs/gui/UnifiedGridRenderer.cpp
@@ -21,8 +21,6 @@ Assumptions: The render strategies are compatible and can be layered together.
 #include <QMetaType>
 #include <QTimer>
 #include <QtEndian>
-#include <QFont>
-#include <QFontDatabase>
 #include <QStringList>
 #include <algorithm>
 #include <cmath>
@@ -30,8 +28,8 @@ Assumptions: The render strategies are compatible and can be layered together.
 // New modular architecture includes
 #include "render/GridViewState.hpp"
 #include "render/DataProcessor.hpp"
-#include "render/GlyphAtlas.hpp"
-#include "render/HeatmapGlyphNode.hpp"
+#include "render/MsdfAtlas.hpp"
+#include "render/MsdfGlyphNode.hpp"
 #include "render/HeatmapIntensityNode.hpp"
 #include "render/HeatmapStreamState.hpp"
 #include "render/ViewportAutoScrollController.hpp"
@@ -394,7 +392,7 @@ void UnifiedGridRenderer::init() {
     m_autoScrollController = std::make_unique<ViewportAutoScrollController>();
     m_autoScrollController->setPaddingFrac(m_autoScrollPaddingFrac);
     m_autoScrollController->setSmoothEnabled(m_smoothAutoScrollEnabled);
-    buildGlyphAtlases();
+    buildMsdfAtlas();
     
     // Create DataProcessor on worker thread for background processing
     m_dataProcessorThread = std::make_unique<QThread>();
@@ -911,19 +909,17 @@ QSGNode* UnifiedGridRenderer::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeD
         const float cellH = (srcRect.height() > 0.0f)
             ? static_cast<float>(drawRect.height()) / static_cast<float>(srcRect.height())
             : 0.0f;
-        int labelPx = 24;
+        int labelPx = 14;
         const int envLabelPx = qEnvironmentVariableIntValue("SENTINEL_HEATMAP_LABEL_PX");
         if (envLabelPx > 0) {
             labelPx = envLabelPx;
         }
         const float labelThreshold = static_cast<float>(labelPx);
 
-        if (labelVisible && cellH >= labelThreshold && m_glyphAtlasesBuilt && window()) {
-            const int bucket = pickFontBucket(cellH);
-            const float fontPx = fontBucketPx(bucket);
-            const float scale = (fontPx > 0.0f) ? (cellH / fontPx) : 1.0f;
-            const GlyphAtlas& atlas = m_glyphAtlases[static_cast<size_t>(bucket)];
-            if (!atlas.isBuilt()) {
+        if (labelVisible && cellH >= labelThreshold && m_msdfAtlasBuilt && window()) {
+            const float fontPx = static_cast<float>(m_msdfAtlas.fontPx());
+            const float scale = (fontPx > 0.0f) ? std::clamp(cellH / fontPx, 0.25f, 2.5f) : 1.0f;
+            if (!m_msdfAtlas.isBuilt()) {
                 if (m_whiteGlyphNode) {
                     m_labelWhiteQuads.clear();
                     m_whiteGlyphNode->updateGeometry(m_labelWhiteQuads);
@@ -951,7 +947,7 @@ QSGNode* UnifiedGridRenderer::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeD
                 const bool dollars = (m_liquidityLabelMode != 0);
                 const int latestColumn = m_heatmapStream ? m_heatmapStream->writeColumn() : -1;
                 HeatmapLabelRenderer::buildLabelQuads(snapshot,
-                                                      atlas,
+                                                      m_msdfAtlas,
                                                       m_labelLiquidityRing,
                                                       m_labelIntensityRing,
                                                       m_labelLiquidityScales,
@@ -970,20 +966,22 @@ QSGNode* UnifiedGridRenderer::updatePaintNode(QSGNode* oldNode, UpdatePaintNodeD
                                                       latestColumn);
 
                 if (!m_whiteGlyphNode) {
-                    m_whiteGlyphNode = new HeatmapGlyphNode();
+                    m_whiteGlyphNode = new MsdfGlyphNode();
                     m_whiteGlyphNode->setColor(Qt::white);
                     m_whiteGlyphNode->ensureCapacity(32000);
                     texNode->appendChildNode(m_whiteGlyphNode);
                 }
                 if (!m_blackGlyphNode) {
-                    m_blackGlyphNode = new HeatmapGlyphNode();
+                    m_blackGlyphNode = new MsdfGlyphNode();
                     m_blackGlyphNode->setColor(Qt::black);
                     m_blackGlyphNode->ensureCapacity(32000);
                     texNode->appendChildNode(m_blackGlyphNode);
                 }
 
-                m_whiteGlyphNode->setAtlas(atlas.image(), window());
-                m_blackGlyphNode->setAtlas(atlas.image(), window());
+                m_whiteGlyphNode->setAtlas(m_msdfAtlas.image(), window());
+                m_whiteGlyphNode->setPxRange(m_msdfAtlas.pxRange());
+                m_blackGlyphNode->setAtlas(m_msdfAtlas.image(), window());
+                m_blackGlyphNode->setPxRange(m_msdfAtlas.pxRange());
                 m_whiteGlyphNode->updateGeometry(m_labelWhiteQuads);
                 m_blackGlyphNode->updateGeometry(m_labelBlackQuads);
             }
@@ -1085,53 +1083,20 @@ void UnifiedGridRenderer::ensureHeatmapPaletteImage() {
     }
 }
 
-void UnifiedGridRenderer::buildGlyphAtlases() {
-    if (m_glyphAtlasesBuilt) {
+void UnifiedGridRenderer::buildMsdfAtlas() {
+    if (m_msdfAtlasBuilt) {
         return;
     }
-    static const QString charset = QStringLiteral("0123456789.kMB$+-");
-    const std::array<int, 5> sizes = {12, 20, 32, 48, 96};
-    const QFont baseFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
-    for (size_t i = 0; i < m_glyphAtlases.size(); ++i) {
-        QFont font = baseFont;
-        font.setPixelSize(sizes[i]);
-        m_glyphAtlases[i].build(font, charset);
+    MsdfAtlas::BuildParams params;
+    params.fontFamily = "Roboto Mono";
+    params.fontPx = 64;
+    params.pxRange = 8.0f;
+    params.charset = QStringLiteral("0123456789.kMB+-");
+    if (m_msdfAtlas.build(params)) {
         if (qEnvironmentVariableIsSet("SENTINEL_DUMP_GLYPH_ATLAS")) {
-            const QString path = QString("/tmp/sentinel_glyph_atlas_%1.png").arg(sizes[i]);
-            m_glyphAtlases[i].image().save(path);
+            m_msdfAtlas.image().save("/tmp/sentinel_msdf_atlas.png");
         }
-    }
-    m_glyphAtlasesBuilt = true;
-}
-
-int UnifiedGridRenderer::pickFontBucket(float cellHeight) const {
-    if (cellHeight < 18.0f) {
-        return 0;
-    }
-    if (cellHeight < 28.0f) {
-        return 1;
-    }
-    if (cellHeight < 48.0f) {
-        return 2;
-    }
-    if (cellHeight < 80.0f) {
-        return 3;
-    }
-    return 4;
-}
-
-float UnifiedGridRenderer::fontBucketPx(int bucket) const {
-    switch (bucket) {
-    case 0:
-        return 12.0f;
-    case 1:
-        return 20.0f;
-    case 2:
-        return 32.0f;
-    case 3:
-        return 48.0f;
-    default:
-        return 96.0f;
+        m_msdfAtlasBuilt = true;
     }
 }
 
@@ -1254,23 +1219,15 @@ QString UnifiedGridRenderer::getLabelRingMemory() const {
 }
 
 QString UnifiedGridRenderer::getGlyphAtlasMemory() const {
-    qint64 totalBytes = 0;
-    int builtCount = 0;
-    for (const auto& atlas : m_glyphAtlases) {
-        if (!atlas.isBuilt()) {
-            continue;
-        }
-        const QImage& image = atlas.image();
-        if (!image.isNull()) {
-            totalBytes += image.sizeInBytes();
-            ++builtCount;
-        }
+    if (!m_msdfAtlas.isBuilt()) {
+        return "MSDF atlas: N/A";
     }
-    if (totalBytes <= 0) {
-        return "Glyph atlas: N/A";
+    const QImage& image = m_msdfAtlas.image();
+    if (image.isNull()) {
+        return "MSDF atlas: N/A";
     }
-    const double mb = static_cast<double>(totalBytes) / (1024.0 * 1024.0);
-    return QString("Glyph atlas: %1 MB (%2)").arg(mb, 0, 'f', 2).arg(builtCount);
+    const double mb = static_cast<double>(image.sizeInBytes()) / (1024.0 * 1024.0);
+    return QString("MSDF atlas: %1 MB").arg(mb, 0, 'f', 2);
 }
 
 double UnifiedGridRenderer::getUploadBandwidth() const {

--- a/libs/gui/UnifiedGridRenderer.h
+++ b/libs/gui/UnifiedGridRenderer.h
@@ -32,11 +32,12 @@ Assumptions: CoordinateSystem and ChartModeController properties are set from QM
 #include <limits>
 #include "../core/marketdata/model/TradeData.h"
 #include "render/GridViewState.hpp"
-#include "render/GlyphAtlas.hpp"
+#include "render/MsdfAtlas.hpp"
 #include "render/HeatmapLabelRenderer.hpp"
 #include "render/HeatmapStreamState.hpp"
 
 class DataProcessor;
+class MsdfGlyphNode;
 
 /**
  *  UNIFIED GRID RENDERER - SLIM QML ADAPTER
@@ -124,8 +125,8 @@ private:
     double m_heatmapContrast = 1.15;
     double m_heatmapShaderFloor = 0.1;
 
-    std::array<class GlyphAtlas, 5> m_glyphAtlases;
-    bool m_glyphAtlasesBuilt = false;
+    MsdfAtlas m_msdfAtlas;
+    bool m_msdfAtlasBuilt = false;
     int m_labelRingGridWidth = 0;
     int m_labelRingGridHeight = 0;
     std::vector<uint16_t> m_labelLiquidityRing;
@@ -133,8 +134,8 @@ private:
     std::vector<double> m_labelLiquidityScales;
     std::vector<HeatmapLabelRenderer::GlyphQuad> m_labelWhiteQuads;
     std::vector<HeatmapLabelRenderer::GlyphQuad> m_labelBlackQuads;
-    class HeatmapGlyphNode* m_whiteGlyphNode = nullptr;
-    class HeatmapGlyphNode* m_blackGlyphNode = nullptr;
+    class MsdfGlyphNode* m_whiteGlyphNode = nullptr;
+    class MsdfGlyphNode* m_blackGlyphNode = nullptr;
 
     // FPS tracking (updated on render thread, read on GUI thread).
     QElapsedTimer m_fpsTimer;
@@ -235,7 +236,7 @@ public:
     Q_INVOKABLE QString getRingCursorInfo() const;       // e.g., "4256/8192"
     Q_INVOKABLE int getDirtyRegionCount() const;         // Number of dirty tiles/regions
     Q_INVOKABLE QString getLabelRingMemory() const;      // Label ring memory usage
-    Q_INVOKABLE QString getGlyphAtlasMemory() const;     // Glyph atlas memory usage
+    Q_INVOKABLE QString getGlyphAtlasMemory() const;     // MSDF atlas memory usage
 
     //  GRID SYSTEM CONTROLS
     Q_INVOKABLE void setGridMode(int mode);
@@ -311,9 +312,7 @@ protected:
 private:
     void ensureHeatmapImage();
     void ensureHeatmapPaletteImage();
-    void buildGlyphAtlases();
-    int pickFontBucket(float cellHeight) const;
-    float fontBucketPx(int bucket) const;
+    void buildMsdfAtlas();
     void applyLabelUploads(const std::vector<HeatmapStreamState::PendingLabelColumn>& uploads,
                            int gridWidth,
                            int gridHeight);

--- a/libs/gui/qml/controls/LiquidityThresholdFilter.qml
+++ b/libs/gui/qml/controls/LiquidityThresholdFilter.qml
@@ -34,8 +34,7 @@ Column {
     Text {
         text: {
             if (!root.target) return "Min Liquidity: 0.00"
-            var prefix = root.target.liquidityLabelMode !== 0 ? "$" : ""
-            return "Min Liquidity: " + prefix + root.target.heatmapLiquidityThreshold.toFixed(2)
+            return "Min Liquidity: " + root.target.heatmapLiquidityThreshold.toFixed(2)
         }
         color: "#00FF00"
         font.pixelSize: 11

--- a/libs/gui/render/HeatmapLabelRenderer.cpp
+++ b/libs/gui/render/HeatmapLabelRenderer.cpp
@@ -20,7 +20,7 @@ bool useBlackLabel(uint16_t encoded) {
 } // namespace
 
 void HeatmapLabelRenderer::buildLabelQuads(const HeatmapStreamState::Snapshot& snapshot,
-                                           const GlyphAtlas& atlas,
+                                           const MsdfAtlas& atlas,
                                            const std::vector<uint16_t>& liquidityRing,
                                            const std::vector<uint16_t>& intensityRing,
                                            const std::vector<double>& liquidityScales,
@@ -75,6 +75,7 @@ void HeatmapLabelRenderer::buildLabelQuads(const HeatmapStreamState::Snapshot& s
         }
     }
 
+    const float padding = static_cast<float>(atlas.paddingPx());
     for (int j = 0; j < cellsY; ++j) {
         int texY = startY + j;
         if (texY < 0) {
@@ -128,10 +129,10 @@ void HeatmapLabelRenderer::buildLabelQuads(const HeatmapStreamState::Snapshot& s
                 if (glyph.advance <= 0.0f || glyph.uv.isNull()) {
                     continue;
                 }
-                minX = std::min(minX, penX + static_cast<float>(glyph.bounds.left()));
-                maxX = std::max(maxX, penX + static_cast<float>(glyph.bounds.right()));
-                minY = std::min(minY, static_cast<float>(glyph.bounds.top()));
-                maxY = std::max(maxY, static_cast<float>(glyph.bounds.bottom()));
+                minX = std::min(minX, penX + static_cast<float>(glyph.bounds.left()) - padding);
+                maxX = std::max(maxX, penX + static_cast<float>(glyph.bounds.right()) + padding);
+                minY = std::min(minY, static_cast<float>(glyph.bounds.top()) - padding);
+                maxY = std::max(maxY, static_cast<float>(glyph.bounds.bottom()) + padding);
                 penX += glyph.advance;
             }
             if (!std::isfinite(minX) || !std::isfinite(maxX)) {
@@ -151,10 +152,10 @@ void HeatmapLabelRenderer::buildLabelQuads(const HeatmapStreamState::Snapshot& s
                     continue;
                 }
 
-                const float x0 = originX + (penX + glyph.bounds.left()) * scale;
-                const float y0 = originY + (glyph.bounds.top()) * scale;
-                const float x1 = originX + (penX + glyph.bounds.right()) * scale;
-                const float y1 = originY + (glyph.bounds.bottom()) * scale;
+                const float x0 = originX + (penX + glyph.bounds.left() - padding) * scale;
+                const float y0 = originY + (glyph.bounds.top() - padding) * scale;
+                const float x1 = originX + (penX + glyph.bounds.right() + padding) * scale;
+                const float y1 = originY + (glyph.bounds.bottom() + padding) * scale;
 
                 const float u0 = static_cast<float>(glyph.uv.left());
                 const float v0 = static_cast<float>(glyph.uv.top());
@@ -245,8 +246,5 @@ QString HeatmapLabelRenderer::formatLiquidityLabel(double value, bool dollars) {
         number = QString::number(scaled, 'f', 0);
     }
 
-    if (dollars) {
-        return QString("$%1%2").arg(number, suffix);
-    }
     return QString("%1%2").arg(number, suffix);
 }

--- a/libs/gui/render/HeatmapLabelRenderer.hpp
+++ b/libs/gui/render/HeatmapLabelRenderer.hpp
@@ -11,15 +11,15 @@ Threading: Render thread only.
 #include <vector>
 
 #include "HeatmapStreamState.hpp"
-#include "GlyphAtlas.hpp"
-#include "HeatmapGlyphNode.hpp"
+#include "MsdfAtlas.hpp"
+#include "MsdfGlyphNode.hpp"
 
 class HeatmapLabelRenderer {
 public:
-    using GlyphQuad = HeatmapGlyphNode::GlyphQuad;
+    using GlyphQuad = MsdfGlyphNode::GlyphQuad;
 
     static void buildLabelQuads(const HeatmapStreamState::Snapshot& snapshot,
-                                const GlyphAtlas& atlas,
+                                const MsdfAtlas& atlas,
                                 const std::vector<uint16_t>& liquidityRing,
                                 const std::vector<uint16_t>& intensityRing,
                                 const std::vector<double>& liquidityScales,

--- a/libs/gui/widgets/TopToolbar.cpp
+++ b/libs/gui/widgets/TopToolbar.cpp
@@ -71,6 +71,20 @@ TopToolbar::TopToolbar(QWidget* parent)
     liqLabel->setStyleSheet("QLabel { color: #B6C2CF; padding-left: 4px; }");
     addWidget(liqLabel);
 
+    QLabel* modeLabel = new QLabel("Mode", this);
+    modeLabel->setStyleSheet("QLabel { color: #B6C2CF; padding-left: 6px; }");
+    addWidget(modeLabel);
+
+    m_liquidityModeCombo = new QComboBox(this);
+    m_liquidityModeCombo->addItems({"Asset", "USD"});
+    m_liquidityModeCombo->setFixedWidth(80);
+    m_liquidityModeCombo->setToolTip("Liquidity label mode");
+    addWidget(m_liquidityModeCombo);
+    connect(m_liquidityModeCombo,
+            QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this,
+            &TopToolbar::liquidityLabelModeChanged);
+
     m_liquiditySlider = new QSlider(Qt::Horizontal, this);
     m_liquiditySlider->setRange(0, 1000);
     m_liquiditySlider->setFixedWidth(120);

--- a/libs/gui/widgets/TopToolbar.hpp
+++ b/libs/gui/widgets/TopToolbar.hpp
@@ -14,6 +14,7 @@ public:
     QLineEdit* symbolSearch() const { return m_symbolSearch; }
     QSlider* liquiditySlider() const { return m_liquiditySlider; }
     QToolButton* subscribeButton() const { return m_subscribeButton; }
+    QComboBox* liquidityModeCombo() const { return m_liquidityModeCombo; }
 
 signals:
     void subscribeRequested();
@@ -27,6 +28,7 @@ signals:
     void fullscreenToggled();
     void screenshotRequested();
     void liquidityThresholdChanged(double threshold);
+    void liquidityLabelModeChanged(int mode);
 
 private:
     QAction* addIconAction(const QString& iconPath, const QString& text, const QString& tooltip);
@@ -37,5 +39,6 @@ private:
     QComboBox* m_timeframeCombo = nullptr;
     QComboBox* m_chartTypeCombo = nullptr;
     QSlider* m_liquiditySlider = nullptr;
+    QComboBox* m_liquidityModeCombo = nullptr;
     QToolButton* m_subscribeButton = nullptr;
 };


### PR DESCRIPTION
### Motivation
- Improve heatmap label clarity by using the MSDF text pipeline already exercised in the Lab widget so labels remain crisp at arbitrary zoom levels.
- Use a single MSDF atlas with padded UVs to avoid bitmap artifacts and to let the fragment shader produce high-quality scalable glyphs.
- Provide a convenient toolbar toggle to switch liquidity label formatting between asset units and USD so the UI supports both modes.

### Description
- Replaced bitmap glyph path with MSDF: `GlyphAtlas` → `MsdfAtlas` and `HeatmapGlyphNode` → `MsdfGlyphNode`, and wired heatmap label generation to use the MSDF atlas (`HeatmapLabelRenderer` now takes `MsdfAtlas`).
- Updated label geometry to include atlas padding when computing per-glyph bounds/UVs and to generate quads compatible with the MSDF shader for crisp rendering at multiple scales.
- Added MSDF atlas builder and initialization in `UnifiedGridRenderer` (`buildMsdfAtlas()`), swapped atlas usage in `updatePaintNode`, adjusted label threshold/scale logic to pick a sensible small baseline and scale as user zooms.
- Added a toolbar combo (`Asset` / `USD`) plus signal wiring (`TopToolbar` → `MainWindowGPU` → QML `UnifiedGridRenderer`) to control `liquidityLabelMode`, removed the dollar prefix from the threshold UI, and updated memory reporting to show MSDF atlas usage.
- Updated `docs/TODO.md` to reflect completed MSDF wiring and noted next steps (label geo cache and threshold reevaluation).

### Testing
- No automated tests were run for these changes in this session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2a684acc832cbbc48e8890761588)