### PR TITLE
Fix heatmap timeframe switching: wide columns, stale data, and UI mis…

### DIFF
--- a/config/server_config.yaml
+++ b/config/server_config.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
-timeframes_ms: [1000, 60000, 3600000, 86400000]
+timeframes_ms: [1000, 60000, 300000, 900000, 3600000, 14400000, 86400000]
 heatmap:
   grid_width: 5120
   grid_height: 2048

--- a/libs/core/config/ConfigTypes.hpp
+++ b/libs/core/config/ConfigTypes.hpp
@@ -10,7 +10,10 @@ struct ServerHeatmapConfig {
     int gridHeight = 2048;
     double tickSize = 0.0;
     double recenterDelta = 0.01;
-    std::vector<int64_t> timeframesMs{1000, 60000, 3600000, 86400000};
+    // All 7 timeframes that the toolbar exposes: 1s, 1m, 5m, 15m, 1h, 4h, 1D.
+    // The server pre-builds a TWAP heatmap ring buffer for each of these so
+    // the client can switch between any of them without waiting for data.
+    std::vector<int64_t> timeframesMs{1000, 60000, 300000, 900000, 3600000, 14400000, 86400000};
     int64_t activeTimeframeMs = 0;
     double bandFast = 0.15;
     double bandMedium = 0.25;

--- a/libs/gui/UnifiedGridRenderer.cpp
+++ b/libs/gui/UnifiedGridRenderer.cpp
@@ -504,8 +504,23 @@ void UnifiedGridRenderer::setTimeframe(int timeframe_ms) {
     m_timeAuthority.setActiveTimeframeMs(static_cast<int64_t>(timeframe_ms));
     if (m_useGpuHeatmap && timeframe_ms > 0) {
       if (m_heatmapStream) {
+        // Reset the ring buffer so stale data from the previous timeframe
+        // does not appear at the new cadence (which would cause columns to
+        // appear massively wide because old 1 s buckets are treated as 1 m
+        // buckets, stretching the visible window by 60×).
+        const auto snap = m_heatmapStream->snapshot();
+        m_heatmapStream->reset(snap.gridWidth > 0 ? snap.gridWidth : m_heatmapGridWidth,
+                               snap.gridHeight > 0 ? snap.gridHeight : m_heatmapGridHeight,
+                               snap.minPrice, snap.maxPrice, snap.tickSize);
         m_heatmapStream->setAppendMs(timeframe_ms);
       }
+      // Force the viewport to re-initialise for the new cadence so that the
+      // auto-scroll controller chooses a sensible visible time window instead
+      // of keeping the old (now wrong) span.
+      if (m_autoScrollController) {
+        m_autoScrollController->resetSpan();
+      }
+      m_heatmapViewportInitialized = false;
     }
     m_manualTimeframeSet = true;
     m_manualTimeframeTimer.start();
@@ -513,7 +528,11 @@ void UnifiedGridRenderer::setTimeframe(int timeframe_ms) {
       QMetaObject::invokeMethod(
           m_dataProcessor.get(),
           [this, timeframe_ms]() {
-            m_dataProcessor->addTimeframe(timeframe_ms);
+            // Update both the display timeframe and the slice filter so that
+            // only slices belonging to the newly selected timeframe pass
+            // through DataProcessor::onHeatmapSliceReceived.
+            m_dataProcessor->setTimeframe(timeframe_ms);
+            m_dataProcessor->setServerTimeframe(timeframe_ms);
           },
           Qt::QueuedConnection);
     }

--- a/libs/gui/qml/controls/TimeframeSelector.qml
+++ b/libs/gui/qml/controls/TimeframeSelector.qml
@@ -4,15 +4,15 @@ Column {
     id: root
     spacing: 5
     z: 10
-    
+
     // Standard interface for all controls
     property var target: null  // UnifiedGridRenderer instance
     property bool enabled: true
-    property int currentTimeframe: target ? target.timeframeMs : 100
-    
+    property int currentTimeframe: target ? target.timeframeMs : 1000
+
     // Signals
     signal valueChanged(var newValue)
-    
+
     // Update current timeframe when target changes
     Connections {
         target: root.target
@@ -20,174 +20,127 @@ Column {
             root.currentTimeframe = root.target.timeframeMs
         }
     }
-    
-    Text { 
-        text: "Timeframe (ms)"
+
+    Text {
+        text: "Timeframe"
         color: "white"
-        font.pixelSize: 12 
+        font.pixelSize: 12
     }
-    
-    Text { 
-        text: "Select aggregation timeframe:"
-        color: "#CCCCCC"
-        font.pixelSize: 10
-        visible: true 
-    }
-    
+
+    // All timeframes match what the server pre-builds and the TopToolbar
+    // combo: 1s, 1m, 5m, 15m, 1h, 4h, 1D.
+
+    // Row 1: 1s  1m  5m  15m
     Row {
         spacing: 3
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 100 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 100 ? "white" : "white"
-            border.width: root.currentTimeframe === 100 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "100"
-                font.bold: root.currentTimeframe === 100 
-            }
-            MouseArea { 
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(100)
-                        root.valueChanged(100)
-                    }
-                }
-            }
-        }
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 250 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 250 ? "white" : "white"
-            border.width: root.currentTimeframe === 250 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "250"
-                font.bold: root.currentTimeframe === 250 
-            }
-            MouseArea { 
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(250)
-                        root.valueChanged(250)
-                    }
-                }
-            }
-        }
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 500 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 500 ? "white" : "white"
-            border.width: root.currentTimeframe === 500 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "500"
-                font.bold: root.currentTimeframe === 500 
-            }
-            MouseArea { 
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(500)
-                        root.valueChanged(500)
-                    }
-                }
-            }
-        }
-    }
-    
-    Row {
-        spacing: 3
+
         Rectangle {
             width: 40; height: 25
             color: root.currentTimeframe === 1000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 1000 ? "white" : "white"
+            border.color: "white"
             border.width: root.currentTimeframe === 1000 ? 2 : 1
             radius: 3
             enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "1s"
-                font.bold: root.currentTimeframe === 1000 
-            }
-            MouseArea { 
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1s"; font.bold: root.currentTimeframe === 1000 }
+            MouseArea {
                 anchors.fill: parent
                 enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(1000)
-                        root.valueChanged(1000)
-                    }
-                }
+                onClicked: { if (root.target) { root.target.setTimeframe(1000); root.valueChanged(1000) } }
             }
         }
+
         Rectangle {
             width: 40; height: 25
-            color: root.currentTimeframe === 2000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 2000 ? "white" : "white"
-            border.width: root.currentTimeframe === 2000 ? 2 : 1
+            color: root.currentTimeframe === 60000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 60000 ? 2 : 1
             radius: 3
             enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "2s"
-                font.bold: root.currentTimeframe === 2000 
-            }
-            MouseArea { 
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1m"; font.bold: root.currentTimeframe === 60000 }
+            MouseArea {
                 anchors.fill: parent
                 enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(2000)
-                        root.valueChanged(2000)
-                    }
-                }
+                onClicked: { if (root.target) { root.target.setTimeframe(60000); root.valueChanged(60000) } }
             }
         }
+
         Rectangle {
             width: 40; height: 25
-            color: root.currentTimeframe === 5000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: root.currentTimeframe === 5000 ? "white" : "white"
-            border.width: root.currentTimeframe === 5000 ? 2 : 1
+            color: root.currentTimeframe === 300000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 300000 ? 2 : 1
             radius: 3
             enabled: root.enabled && root.target
-            Text { 
-                anchors.centerIn: parent
-                color: "white"
-                font.pixelSize: 9
-                text: "5s"
-                font.bold: root.currentTimeframe === 5000 
-            }
-            MouseArea { 
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "5m"; font.bold: root.currentTimeframe === 300000 }
+            MouseArea {
                 anchors.fill: parent
                 enabled: root.enabled && root.target
-                onClicked: {
-                    if (root.target) {
-                        root.target.setTimeframe(5000)
-                        root.valueChanged(5000)
-                    }
-                }
+                onClicked: { if (root.target) { root.target.setTimeframe(300000); root.valueChanged(300000) } }
+            }
+        }
+
+        Rectangle {
+            width: 40; height: 25
+            color: root.currentTimeframe === 900000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 900000 ? 2 : 1
+            radius: 3
+            enabled: root.enabled && root.target
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "15m"; font.bold: root.currentTimeframe === 900000 }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.enabled && root.target
+                onClicked: { if (root.target) { root.target.setTimeframe(900000); root.valueChanged(900000) } }
+            }
+        }
+    }
+
+    // Row 2: 1h  4h  1D
+    Row {
+        spacing: 3
+
+        Rectangle {
+            width: 40; height: 25
+            color: root.currentTimeframe === 3600000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 3600000 ? 2 : 1
+            radius: 3
+            enabled: root.enabled && root.target
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1h"; font.bold: root.currentTimeframe === 3600000 }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.enabled && root.target
+                onClicked: { if (root.target) { root.target.setTimeframe(3600000); root.valueChanged(3600000) } }
+            }
+        }
+
+        Rectangle {
+            width: 40; height: 25
+            color: root.currentTimeframe === 14400000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 14400000 ? 2 : 1
+            radius: 3
+            enabled: root.enabled && root.target
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "4h"; font.bold: root.currentTimeframe === 14400000 }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.enabled && root.target
+                onClicked: { if (root.target) { root.target.setTimeframe(14400000); root.valueChanged(14400000) } }
+            }
+        }
+
+        Rectangle {
+            width: 40; height: 25
+            color: root.currentTimeframe === 86400000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === 86400000 ? 2 : 1
+            radius: 3
+            enabled: root.enabled && root.target
+            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1D"; font.bold: root.currentTimeframe === 86400000 }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.enabled && root.target
+                onClicked: { if (root.target) { root.target.setTimeframe(86400000); root.valueChanged(86400000) } }
             }
         }
     }

--- a/libs/gui/qml/controls/TimeframeSelector.qml
+++ b/libs/gui/qml/controls/TimeframeSelector.qml
@@ -5,15 +5,22 @@ Column {
     spacing: 5
     z: 10
 
-    // Standard interface for all controls
-    property var target: null  // UnifiedGridRenderer instance
+    property var target: null
     property bool enabled: true
     property int currentTimeframe: target ? target.timeframeMs : 1000
 
-    // Signals
     signal valueChanged(var newValue)
 
-    // Update current timeframe when target changes
+    property var timeframes: [
+        { text: "1s",  value: 1000      },
+        { text: "1m",  value: 60000     },
+        { text: "5m",  value: 300000    },
+        { text: "15m", value: 900000    },
+        { text: "1h",  value: 3600000   },
+        { text: "4h",  value: 14400000  },
+        { text: "1D",  value: 86400000  }
+    ]
+
     Connections {
         target: root.target
         function onTimeframeChanged() {
@@ -27,121 +34,50 @@ Column {
         font.pixelSize: 12
     }
 
-    // All timeframes match what the server pre-builds and the TopToolbar
-    // combo: 1s, 1m, 5m, 15m, 1h, 4h, 1D.
+    // Button template instantiated by each Repeater below.
+    // modelData is the JS object { text, value } from the timeframes array.
+    Component {
+        id: timeframeButton
+        Rectangle {
+            width: 40; height: 25
+            radius: 3
+            color: root.currentTimeframe === modelData.value
+                   ? Qt.rgba(0, 0.8, 0, 0.9)
+                   : Qt.rgba(0, 0, 0.4, 0.8)
+            border.color: "white"
+            border.width: root.currentTimeframe === modelData.value ? 2 : 1
+            enabled: root.enabled && root.target
+
+            Text {
+                anchors.centerIn: parent
+                color: "white"
+                font.pixelSize: 9
+                font.bold: root.currentTimeframe === modelData.value
+                text: modelData.text
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.enabled && root.target
+                onClicked: {
+                    if (root.target) {
+                        root.target.setTimeframe(modelData.value)
+                        root.valueChanged(modelData.value)
+                    }
+                }
+            }
+        }
+    }
 
     // Row 1: 1s  1m  5m  15m
     Row {
         spacing: 3
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 1000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 1000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1s"; font.bold: root.currentTimeframe === 1000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(1000); root.valueChanged(1000) } }
-            }
-        }
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 60000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 60000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1m"; font.bold: root.currentTimeframe === 60000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(60000); root.valueChanged(60000) } }
-            }
-        }
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 300000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 300000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "5m"; font.bold: root.currentTimeframe === 300000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(300000); root.valueChanged(300000) } }
-            }
-        }
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 900000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 900000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "15m"; font.bold: root.currentTimeframe === 900000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(900000); root.valueChanged(900000) } }
-            }
-        }
+        Repeater { model: root.timeframes.slice(0, 4); delegate: timeframeButton }
     }
 
     // Row 2: 1h  4h  1D
     Row {
         spacing: 3
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 3600000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 3600000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1h"; font.bold: root.currentTimeframe === 3600000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(3600000); root.valueChanged(3600000) } }
-            }
-        }
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 14400000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 14400000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "4h"; font.bold: root.currentTimeframe === 14400000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(14400000); root.valueChanged(14400000) } }
-            }
-        }
-
-        Rectangle {
-            width: 40; height: 25
-            color: root.currentTimeframe === 86400000 ? Qt.rgba(0, 0.8, 0, 0.9) : Qt.rgba(0, 0, 0.4, 0.8)
-            border.color: "white"
-            border.width: root.currentTimeframe === 86400000 ? 2 : 1
-            radius: 3
-            enabled: root.enabled && root.target
-            Text { anchors.centerIn: parent; color: "white"; font.pixelSize: 9; text: "1D"; font.bold: root.currentTimeframe === 86400000 }
-            MouseArea {
-                anchors.fill: parent
-                enabled: root.enabled && root.target
-                onClicked: { if (root.target) { root.target.setTimeframe(86400000); root.valueChanged(86400000) } }
-            }
-        }
+        Repeater { model: root.timeframes.slice(4, 7); delegate: timeframeButton }
     }
 }


### PR DESCRIPTION
Three root causes caused columns to become massively wide when switching timeframes from the toolbar:

1. **Stale ring-buffer data at wrong cadence** – `setTimeframe()` only updated `appendMs` on the stream state but left the ring buffer full of old 1-second buckets. The renderer then mapped those columns to the new (longer) cadence, making each visible column 60× wider than expected when going from 1 s → 1 m.

2. **DataProcessor slice filter not updated** – `m_forcedTimeframeMs` in DataProcessor was set once at startup (to the first server timeframe, 1 000 ms) and never changed on user-driven timeframe switches. Incoming slices for the selected timeframe were silently dropped, so no new data arrived and the stale ring buffer was never replaced.

3. **Viewport span not re-initialised** – After a cadence change the auto-scroll controller kept its cached `m_autoScrollSpanMs` from the previous timeframe, so the visible time window stayed wrong until a manual zoom.

Fixes applied:
- `UnifiedGridRenderer::setTimeframe`: reset the heatmap ring buffer before changing cadence, call `resetSpan()` + clear `m_heatmapViewportInitialized` so the viewport re-initialises cleanly, and invoke `DataProcessor::setTimeframe` + `setServerTimeframe` on the worker thread so the correct timeframe slices pass through.
- `ConfigTypes.hpp` + `server_config.yaml`: expand default `timeframesMs` from {1s,1m,1h,1D} to all 7 toolbar timeframes {1s,1m,5m,15m,1h,4h,1D} so the server pre-builds ring buffers for every option the client can select.
- `TimeframeSelector.qml`: replace the old sub-second buttons (100 ms – 5 s) with the same 7 timeframes (1s,1m,5m,15m,1h,4h,1D) that the TopToolbar combo exposes, keeping the in-chart overlay in sync.

https://claude.ai/code/session_01NfCDJnfwMKJz4kdFRKdXoc