### PR TITLE
feat(watchlist): add preset watchlists with auto-routing to heatmap/s…

### DIFF
--- a/libs/gui/MainWindowGpu.cpp
+++ b/libs/gui/MainWindowGpu.cpp
@@ -213,6 +213,18 @@ void MainWindowGPU::setupUI() {
             }
         });
     }
+    if (m_watchlistDock) {
+        connect(m_watchlistDock, &WatchlistDock::symbolSelected, this, [this](const QString& symbol, const QString& assetType) {
+            if (assetType == "crypto" && m_symbolInput) {
+                m_symbolInput->setText(symbol);
+                onSubscribe();
+            } else if (assetType == "stock" && m_stockChartDock) {
+                m_stockChartDock->show();
+                m_stockChartDock->raise();
+                m_stockChartDock->loadSymbol(symbol);
+            }
+        });
+    }
     
     m_qquickView = m_heatmapDock->qquickView();
     m_qmlContainer = m_heatmapDock->qmlContainer();

--- a/libs/gui/MainWindowGpu.cpp
+++ b/libs/gui/MainWindowGpu.cpp
@@ -202,28 +202,12 @@ void MainWindowGPU::setupUI() {
         if (auto* remote = dynamic_cast<RemoteGridDataSource*>(m_dataSource.get())) {
             m_screenerDock->setStreamClient(remote->streamClient());
         }
-        connect(m_screenerDock, &ScreenerDock::rowSelected, this, [this](const QString& symbol, const QString& assetType) {
-            if (assetType == "crypto" && m_symbolInput) {
-                m_symbolInput->setText(symbol);
-                onSubscribe();
-            } else if (assetType == "stock" && m_stockChartDock) {
-                m_stockChartDock->show();
-                m_stockChartDock->raise();
-                m_stockChartDock->loadSymbol(symbol);
-            }
-        });
+        connect(m_screenerDock, &ScreenerDock::rowSelected,
+                this, &MainWindowGPU::onAssetSymbolSelected);
     }
     if (m_watchlistDock) {
-        connect(m_watchlistDock, &WatchlistDock::symbolSelected, this, [this](const QString& symbol, const QString& assetType) {
-            if (assetType == "crypto" && m_symbolInput) {
-                m_symbolInput->setText(symbol);
-                onSubscribe();
-            } else if (assetType == "stock" && m_stockChartDock) {
-                m_stockChartDock->show();
-                m_stockChartDock->raise();
-                m_stockChartDock->loadSymbol(symbol);
-            }
-        });
+        connect(m_watchlistDock, &WatchlistDock::symbolSelected,
+                this, &MainWindowGPU::onAssetSymbolSelected);
     }
     
     m_qquickView = m_heatmapDock->qquickView();
@@ -416,6 +400,17 @@ void MainWindowGPU::setupGuiApiServer() {
                                                     this);
     if (!m_guiApiServer->start(static_cast<quint16>(port), screenshotDir)) {
         sLog_Error("GUI API failed to bind on port " << port << ": " << m_guiApiServer->errorString());
+    }
+}
+
+void MainWindowGPU::onAssetSymbolSelected(const QString& symbol, const QString& assetType) {
+    if (assetType == QLatin1String("crypto") && m_symbolInput) {
+        m_symbolInput->setText(symbol);
+        onSubscribe();
+    } else if (assetType == QLatin1String("stock") && m_stockChartDock) {
+        m_stockChartDock->show();
+        m_stockChartDock->raise();
+        m_stockChartDock->loadSymbol(symbol);
     }
 }
 

--- a/libs/gui/MainWindowGpu.h
+++ b/libs/gui/MainWindowGpu.h
@@ -62,6 +62,8 @@ private slots:
     void onSubscribe();
     void onConnectionStatusChanged(bool connected);
     void resetLayoutToDefault();
+    // Shared routing slot for screener and watchlist symbol selections.
+    void onAssetSymbolSelected(const QString& symbol, const QString& assetType);
 
 protected:
     void closeEvent(QCloseEvent* event) override;

--- a/libs/gui/widgets/WatchlistDock.cpp
+++ b/libs/gui/widgets/WatchlistDock.cpp
@@ -1,5 +1,6 @@
 #include "WatchlistDock.hpp"
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
 #include <QBrush>
@@ -11,12 +12,156 @@ WatchlistDock::WatchlistDock(QWidget* parent)
     , m_tree(new QTreeView(m_contentWidget))
     , m_model(new QStandardItemModel(this))
 {
+    initPresets();
     buildUi();
-    populatePlaceholderData();
+    if (!m_presets.isEmpty()) {
+        loadPreset(0);
+    }
 }
 
 QSize WatchlistDock::minimumSizeHint() const {
-    return QSize(320, 360);
+    return QSize(320, 400);
+}
+
+void WatchlistDock::initPresets() {
+    // ── Major Indices ────────────────────────────────────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "Major Indices";
+        p.assetType = "stock";
+        p.symbols   = {
+            {"SPY",  "S&P 500 ETF"},
+            {"QQQ",  "NASDAQ 100 ETF"},
+            {"DIA",  "Dow Jones ETF"},
+            {"IWM",  "Russell 2000 ETF"},
+            {"MDY",  "S&P MidCap 400 ETF"},
+            {"VTI",  "Total Stock Market ETF"},
+            {"VEA",  "Developed Markets ETF"},
+            {"VWO",  "Emerging Markets ETF"},
+            {"EFA",  "iShares MSCI EAFE ETF"},
+            {"EEM",  "iShares MSCI EM ETF"},
+        };
+        m_presets.append(p);
+    }
+
+    // ── XL Sectors (SPDR Select Sector ETFs) ────────────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "XL Sectors";
+        p.assetType = "stock";
+        p.symbols   = {
+            {"XLK",  "Technology"},
+            {"XLF",  "Financials"},
+            {"XLV",  "Health Care"},
+            {"XLY",  "Consumer Discretionary"},
+            {"XLP",  "Consumer Staples"},
+            {"XLE",  "Energy"},
+            {"XLI",  "Industrials"},
+            {"XLB",  "Materials"},
+            {"XLRE", "Real Estate"},
+            {"XLU",  "Utilities"},
+            {"XLC",  "Communication Services"},
+        };
+        m_presets.append(p);
+    }
+
+    // ── Commodities (ETF proxies) ────────────────────────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "Commodities";
+        p.assetType = "stock";
+        p.symbols   = {
+            {"GLD",  "Gold ETF"},
+            {"SLV",  "Silver ETF"},
+            {"USO",  "US Oil Fund"},
+            {"UNG",  "Natural Gas ETF"},
+            {"CORN", "Corn ETF"},
+            {"WEAT", "Wheat ETF"},
+            {"SOYB", "Soybeans ETF"},
+            {"CPER", "Copper ETF"},
+            {"PALL", "Palladium ETF"},
+            {"PPLT", "Platinum ETF"},
+            {"DBA",  "Agri Commodity ETF"},
+            {"DJP",  "Bloomberg Commodity"},
+        };
+        m_presets.append(p);
+    }
+
+    // ── Top Stocks ───────────────────────────────────────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "Top Stocks";
+        p.assetType = "stock";
+        p.symbols   = {
+            {"AAPL",  "Apple"},
+            {"NVDA",  "NVIDIA"},
+            {"MSFT",  "Microsoft"},
+            {"AMZN",  "Amazon"},
+            {"GOOGL", "Alphabet"},
+            {"META",  "Meta Platforms"},
+            {"TSLA",  "Tesla"},
+            {"AVGO",  "Broadcom"},
+            {"JPM",   "JPMorgan Chase"},
+            {"V",     "Visa"},
+            {"UNH",   "UnitedHealth"},
+            {"LLY",   "Eli Lilly"},
+            {"XOM",   "ExxonMobil"},
+            {"JNJ",   "Johnson & Johnson"},
+            {"WMT",   "Walmart"},
+            {"MA",    "Mastercard"},
+            {"PG",    "Procter & Gamble"},
+            {"HD",    "Home Depot"},
+            {"COST",  "Costco"},
+            {"ORCL",  "Oracle"},
+        };
+        m_presets.append(p);
+    }
+
+    // ── Fixed Income / Bonds ─────────────────────────────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "Fixed Income";
+        p.assetType = "stock";
+        p.symbols   = {
+            {"TLT",  "20yr Treasury ETF"},
+            {"IEF",  "7-10yr Treasury ETF"},
+            {"SHY",  "1-3yr Treasury ETF"},
+            {"BND",  "Vanguard Bond ETF"},
+            {"AGG",  "US Agg Bond ETF"},
+            {"HYG",  "High Yield Corp ETF"},
+            {"LQD",  "Invest Grade Corp ETF"},
+            {"TIP",  "TIPS ETF"},
+            {"MBB",  "Mortgage-Backed ETF"},
+            {"VCSH", "Short-Term Corp ETF"},
+            {"VCIT", "Interm-Term Corp ETF"},
+        };
+        m_presets.append(p);
+    }
+
+    // ── Crypto (Coinbase pairs — routed to heatmap) ──────────────────────────
+    {
+        WatchlistPreset p;
+        p.name      = "Crypto";
+        p.assetType = "crypto";
+        p.symbols   = {
+            {"BTC-USD",  "Bitcoin"},
+            {"ETH-USD",  "Ethereum"},
+            {"SOL-USD",  "Solana"},
+            {"XRP-USD",  "Ripple"},
+            {"DOGE-USD", "Dogecoin"},
+            {"ADA-USD",  "Cardano"},
+            {"AVAX-USD", "Avalanche"},
+            {"LINK-USD", "Chainlink"},
+            {"DOT-USD",  "Polkadot"},
+            {"LTC-USD",  "Litecoin"},
+            {"UNI-USD",  "Uniswap"},
+            {"ATOM-USD", "Cosmos"},
+            {"NEAR-USD", "NEAR Protocol"},
+            {"BCH-USD",  "Bitcoin Cash"},
+            {"MATIC-USD","Polygon"},
+        };
+        m_presets.append(p);
+    }
 }
 
 void WatchlistDock::buildUi() {
@@ -24,11 +169,42 @@ void WatchlistDock::buildUi() {
     layout->setContentsMargins(8, 8, 8, 8);
     layout->setSpacing(6);
 
-    QLabel* header = new QLabel("Main Watchlist", m_contentWidget);
-    header->setStyleSheet("QLabel { color: #D0D6DD; font-weight: 600; letter-spacing: 0.2px; }");
-    layout->addWidget(header);
+    // ── Preset selector row ──────────────────────────────────────────────────
+    QHBoxLayout* topRow = new QHBoxLayout();
+    topRow->setSpacing(6);
 
-    m_model->setHorizontalHeaderLabels({"Symbol", "Last", "Chg", "Chg%", "Vol"});
+    QLabel* listLabel = new QLabel("Watchlist:", m_contentWidget);
+    listLabel->setStyleSheet("QLabel { color: #8FA3B8; font-size: 11px; }");
+    topRow->addWidget(listLabel);
+
+    m_presetCombo = new QComboBox(m_contentWidget);
+    for (const auto& preset : m_presets) {
+        m_presetCombo->addItem(preset.name);
+    }
+    m_presetCombo->setStyleSheet(
+        "QComboBox {"
+        "  background-color: #2A2F38;"
+        "  color: #D0D6DD;"
+        "  border: 1px solid #3C4450;"
+        "  border-radius: 4px;"
+        "  padding: 3px 8px;"
+        "  font-weight: 600;"
+        "}"
+        "QComboBox::drop-down { border: none; width: 20px; }"
+        "QComboBox QAbstractItemView {"
+        "  background-color: #1E2530;"
+        "  color: #D0D6DD;"
+        "  selection-background-color: #2E5FA3;"
+        "}"
+    );
+    topRow->addWidget(m_presetCombo, 1);
+    layout->addLayout(topRow);
+
+    // ── Asset type badge ─────────────────────────────────────────────────────
+    // (shown inline in the tree as a section header per preset)
+
+    // ── Tree view ────────────────────────────────────────────────────────────
+    m_model->setHorizontalHeaderLabels({"Symbol", "Name"});
     m_tree->setModel(m_model);
     m_tree->setRootIsDecorated(false);
     m_tree->setAlternatingRowColors(true);
@@ -37,56 +213,82 @@ void WatchlistDock::buildUi() {
     m_tree->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
     m_tree->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_tree->setStyleSheet(
+        "QTreeView { background-color: #1A1F28; alternate-background-color: #1E2530; color: #D0D6DD; }"
+        "QTreeView::item:selected { background-color: #2E5FA3; color: #FFFFFF; }"
+        "QTreeView::item:hover { background-color: #253040; }"
+        "QHeaderView::section { background-color: #252B36; color: #8FA3B8; border: none; padding: 4px; }"
+    );
 
     auto* headerView = m_tree->header();
-    headerView->setStretchLastSection(false);
-    headerView->setSectionResizeMode(0, QHeaderView::Stretch);
-    for (int i = 1; i < m_model->columnCount(); ++i) {
-        headerView->setSectionResizeMode(i, QHeaderView::ResizeToContents);
-    }
+    headerView->setStretchLastSection(true);
+    headerView->setSectionResizeMode(0, QHeaderView::ResizeToContents);
 
     layout->addWidget(m_tree, 1);
     m_contentWidget->setLayout(layout);
+
+    connect(m_presetCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &WatchlistDock::onPresetChanged);
+    connect(m_tree, &QTreeView::clicked, this, &WatchlistDock::onRowClicked);
 }
 
-void WatchlistDock::populatePlaceholderData() {
+void WatchlistDock::loadPreset(int index) {
+    if (index < 0 || index >= m_presets.size()) {
+        return;
+    }
     m_model->removeRows(0, m_model->rowCount());
 
-    auto addSection = [this](const QString& name, const QList<QStringList>& rows) {
-        QList<QStandardItem*> sectionRow;
-        auto* sectionItem = new QStandardItem(name);
-        sectionItem->setData(true, Qt::UserRole + 1);
-        sectionItem->setForeground(QBrush(QColor("#8FA3B8")));
-        sectionItem->setFont(QFont("", -1, QFont::DemiBold));
-        sectionItem->setFlags(Qt::ItemIsEnabled);
-        sectionRow << sectionItem;
-        for (int i = 1; i < m_model->columnCount(); ++i) {
-            sectionRow << new QStandardItem("");
-        }
-        m_model->appendRow(sectionRow);
+    const WatchlistPreset& preset = m_presets[index];
 
-        for (const auto& row : rows) {
-            QList<QStandardItem*> items;
-            for (int i = 0; i < row.size(); ++i) {
-                auto* item = new QStandardItem(row[i]);
-                items << item;
-            }
-            while (items.size() < m_model->columnCount()) {
-                items << new QStandardItem("");
-            }
-            m_model->appendRow(items);
-        }
-    };
+    // Section header row showing asset type
+    {
+        const QString badge = (preset.assetType == "crypto") ? "● CRYPTO" : "● STOCKS";
+        const QString badgeColor = (preset.assetType == "crypto") ? "#F7931A" : "#4CAF50";
+        auto* headerItem = new QStandardItem(badge);
+        headerItem->setData(true, Qt::UserRole + 1); // mark as section
+        headerItem->setForeground(QBrush(QColor(badgeColor)));
+        QFont f;
+        f.setBold(true);
+        f.setPointSize(9);
+        headerItem->setFont(f);
+        headerItem->setFlags(Qt::ItemIsEnabled); // not selectable
+        auto* headerDesc = new QStandardItem(preset.name);
+        headerDesc->setForeground(QBrush(QColor("#6B7A8D")));
+        headerDesc->setFlags(Qt::ItemIsEnabled);
+        m_model->appendRow({headerItem, headerDesc});
+    }
 
-    addSection("CRYPTO", {
-        {"BTC-USD", "88,493", "+243", "+0.28%", "9.8K"},
-        {"ETH-USD", "3,091", "+10", "+0.33%", "8.1K"},
-        {"SOL-USD", "243", "-1.2", "-0.49%", "1.9K"}
-    });
+    for (const auto& sym : preset.symbols) {
+        auto* tickerItem = new QStandardItem(sym.first);
+        tickerItem->setData(sym.first, Qt::UserRole + 2);    // ticker
+        tickerItem->setData(preset.assetType, Qt::UserRole + 3); // assetType
+        auto* nameItem = new QStandardItem(sym.second);
+        nameItem->setForeground(QBrush(QColor("#8FA3B8")));
+        m_model->appendRow({tickerItem, nameItem});
+    }
+}
 
-    addSection("US MARKETS", {
-        {"AAPL", "193.8", "+1.2", "+0.62%", "42.1M"},
-        {"NVDA", "637.1", "+8.4", "+1.34%", "36.7M"},
-        {"SPY", "467.0", "+0.9", "+0.20%", "58.3M"}
-    });
+void WatchlistDock::onPresetChanged(int index) {
+    loadPreset(index);
+}
+
+void WatchlistDock::onRowClicked(const QModelIndex& index) {
+    if (!index.isValid()) {
+        return;
+    }
+    // Get the first-column item
+    QModelIndex firstCol = m_model->index(index.row(), 0);
+    QStandardItem* item  = m_model->itemFromIndex(firstCol);
+    if (!item) {
+        return;
+    }
+    // Skip section-header rows
+    if (item->data(Qt::UserRole + 1).toBool()) {
+        return;
+    }
+    const QString ticker    = item->data(Qt::UserRole + 2).toString();
+    const QString assetType = item->data(Qt::UserRole + 3).toString();
+    if (!ticker.isEmpty() && !assetType.isEmpty()) {
+        emit symbolSelected(ticker, assetType);
+    }
 }

--- a/libs/gui/widgets/WatchlistDock.cpp
+++ b/libs/gui/widgets/WatchlistDock.cpp
@@ -7,6 +7,14 @@
 #include <QColor>
 #include <QFont>
 
+// Named constants for section-header badge rendering
+namespace {
+constexpr const char* kCryptoBadgeText  = "● CRYPTO";
+constexpr const char* kStockBadgeText   = "● STOCKS";
+constexpr const char* kCryptoBadgeColor = "#F7931A";
+constexpr const char* kStockBadgeColor  = "#4CAF50";
+} // namespace
+
 WatchlistDock::WatchlistDock(QWidget* parent)
     : DockablePanel("WatchlistDock", "Watchlist", parent)
     , m_tree(new QTreeView(m_contentWidget))
@@ -24,12 +32,15 @@ QSize WatchlistDock::minimumSizeHint() const {
 }
 
 void WatchlistDock::initPresets() {
-    // ── Major Indices ────────────────────────────────────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "Major Indices";
-        p.assetType = "stock";
-        p.symbols   = {
+    // Helper: build a preset inline without a named local variable
+    auto make = [](const QString& name, AssetType type,
+                   QVector<QPair<QString, QString>> symbols) -> WatchlistPreset {
+        return {name, type, std::move(symbols)};
+    };
+
+    m_presets = {
+        // ── Major Indices ────────────────────────────────────────────────────
+        make("Major Indices", AssetType::Stock, {
             {"SPY",  "S&P 500 ETF"},
             {"QQQ",  "NASDAQ 100 ETF"},
             {"DIA",  "Dow Jones ETF"},
@@ -40,16 +51,10 @@ void WatchlistDock::initPresets() {
             {"VWO",  "Emerging Markets ETF"},
             {"EFA",  "iShares MSCI EAFE ETF"},
             {"EEM",  "iShares MSCI EM ETF"},
-        };
-        m_presets.append(p);
-    }
+        }),
 
-    // ── XL Sectors (SPDR Select Sector ETFs) ────────────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "XL Sectors";
-        p.assetType = "stock";
-        p.symbols   = {
+        // ── XL Sectors (SPDR Select Sector ETFs) ────────────────────────────
+        make("XL Sectors", AssetType::Stock, {
             {"XLK",  "Technology"},
             {"XLF",  "Financials"},
             {"XLV",  "Health Care"},
@@ -61,16 +66,10 @@ void WatchlistDock::initPresets() {
             {"XLRE", "Real Estate"},
             {"XLU",  "Utilities"},
             {"XLC",  "Communication Services"},
-        };
-        m_presets.append(p);
-    }
+        }),
 
-    // ── Commodities (ETF proxies) ────────────────────────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "Commodities";
-        p.assetType = "stock";
-        p.symbols   = {
+        // ── Commodities (ETF proxies) ────────────────────────────────────────
+        make("Commodities", AssetType::Stock, {
             {"GLD",  "Gold ETF"},
             {"SLV",  "Silver ETF"},
             {"USO",  "US Oil Fund"},
@@ -83,16 +82,10 @@ void WatchlistDock::initPresets() {
             {"PPLT", "Platinum ETF"},
             {"DBA",  "Agri Commodity ETF"},
             {"DJP",  "Bloomberg Commodity"},
-        };
-        m_presets.append(p);
-    }
+        }),
 
-    // ── Top Stocks ───────────────────────────────────────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "Top Stocks";
-        p.assetType = "stock";
-        p.symbols   = {
+        // ── Top Stocks ───────────────────────────────────────────────────────
+        make("Top Stocks", AssetType::Stock, {
             {"AAPL",  "Apple"},
             {"NVDA",  "NVIDIA"},
             {"MSFT",  "Microsoft"},
@@ -113,16 +106,10 @@ void WatchlistDock::initPresets() {
             {"HD",    "Home Depot"},
             {"COST",  "Costco"},
             {"ORCL",  "Oracle"},
-        };
-        m_presets.append(p);
-    }
+        }),
 
-    // ── Fixed Income / Bonds ─────────────────────────────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "Fixed Income";
-        p.assetType = "stock";
-        p.symbols   = {
+        // ── Fixed Income / Bonds ─────────────────────────────────────────────
+        make("Fixed Income", AssetType::Stock, {
             {"TLT",  "20yr Treasury ETF"},
             {"IEF",  "7-10yr Treasury ETF"},
             {"SHY",  "1-3yr Treasury ETF"},
@@ -134,16 +121,10 @@ void WatchlistDock::initPresets() {
             {"MBB",  "Mortgage-Backed ETF"},
             {"VCSH", "Short-Term Corp ETF"},
             {"VCIT", "Interm-Term Corp ETF"},
-        };
-        m_presets.append(p);
-    }
+        }),
 
-    // ── Crypto (Coinbase pairs — routed to heatmap) ──────────────────────────
-    {
-        WatchlistPreset p;
-        p.name      = "Crypto";
-        p.assetType = "crypto";
-        p.symbols   = {
+        // ── Crypto (Coinbase pairs — routed to heatmap) ──────────────────────
+        make("Crypto", AssetType::Crypto, {
             {"BTC-USD",  "Bitcoin"},
             {"ETH-USD",  "Ethereum"},
             {"SOL-USD",  "Solana"},
@@ -159,9 +140,8 @@ void WatchlistDock::initPresets() {
             {"NEAR-USD", "NEAR Protocol"},
             {"BCH-USD",  "Bitcoin Cash"},
             {"MATIC-USD","Polygon"},
-        };
-        m_presets.append(p);
-    }
+        }),
+    };
 }
 
 void WatchlistDock::buildUi() {
@@ -200,9 +180,6 @@ void WatchlistDock::buildUi() {
     topRow->addWidget(m_presetCombo, 1);
     layout->addLayout(topRow);
 
-    // ── Asset type badge ─────────────────────────────────────────────────────
-    // (shown inline in the tree as a section header per preset)
-
     // ── Tree view ────────────────────────────────────────────────────────────
     m_model->setHorizontalHeaderLabels({"Symbol", "Name"});
     m_tree->setModel(m_model);
@@ -239,31 +216,38 @@ void WatchlistDock::loadPreset(int index) {
     m_model->removeRows(0, m_model->rowCount());
 
     const WatchlistPreset& preset = m_presets[index];
+    const bool isCrypto = (preset.assetType == AssetType::Crypto);
 
-    // Section header row showing asset type
+    // Section header row — uses named badge constants
     {
-        const QString badge = (preset.assetType == "crypto") ? "● CRYPTO" : "● STOCKS";
-        const QString badgeColor = (preset.assetType == "crypto") ? "#F7931A" : "#4CAF50";
-        auto* headerItem = new QStandardItem(badge);
-        headerItem->setData(true, Qt::UserRole + 1); // mark as section
-        headerItem->setForeground(QBrush(QColor(badgeColor)));
+        const char* badgeText  = isCrypto ? kCryptoBadgeText  : kStockBadgeText;
+        const char* badgeColor = isCrypto ? kCryptoBadgeColor : kStockBadgeColor;
+
+        auto* headerItem = new QStandardItem(QLatin1String(badgeText));
+        headerItem->setData(true, IsSectionRole);
+        headerItem->setForeground(QBrush(QColor(QLatin1String(badgeColor))));
         QFont f;
         f.setBold(true);
         f.setPointSize(9);
         headerItem->setFont(f);
-        headerItem->setFlags(Qt::ItemIsEnabled); // not selectable
+        headerItem->setFlags(Qt::ItemIsEnabled);
+
         auto* headerDesc = new QStandardItem(preset.name);
         headerDesc->setForeground(QBrush(QColor("#6B7A8D")));
         headerDesc->setFlags(Qt::ItemIsEnabled);
+
         m_model->appendRow({headerItem, headerDesc});
     }
 
+    const QString assetTypeStr = assetTypeString(preset.assetType);
     for (const auto& sym : preset.symbols) {
         auto* tickerItem = new QStandardItem(sym.first);
-        tickerItem->setData(sym.first, Qt::UserRole + 2);    // ticker
-        tickerItem->setData(preset.assetType, Qt::UserRole + 3); // assetType
+        tickerItem->setData(sym.first,    TickerRole);
+        tickerItem->setData(assetTypeStr, AssetTypeRole);
+
         auto* nameItem = new QStandardItem(sym.second);
         nameItem->setForeground(QBrush(QColor("#8FA3B8")));
+
         m_model->appendRow({tickerItem, nameItem});
     }
 }
@@ -276,18 +260,12 @@ void WatchlistDock::onRowClicked(const QModelIndex& index) {
     if (!index.isValid()) {
         return;
     }
-    // Get the first-column item
-    QModelIndex firstCol = m_model->index(index.row(), 0);
-    QStandardItem* item  = m_model->itemFromIndex(firstCol);
-    if (!item) {
+    QStandardItem* item = m_model->itemFromIndex(m_model->index(index.row(), 0));
+    if (!item || item->data(IsSectionRole).toBool()) {
         return;
     }
-    // Skip section-header rows
-    if (item->data(Qt::UserRole + 1).toBool()) {
-        return;
-    }
-    const QString ticker    = item->data(Qt::UserRole + 2).toString();
-    const QString assetType = item->data(Qt::UserRole + 3).toString();
+    const QString ticker    = item->data(TickerRole).toString();
+    const QString assetType = item->data(AssetTypeRole).toString();
     if (!ticker.isEmpty() && !assetType.isEmpty()) {
         emit symbolSelected(ticker, assetType);
     }

--- a/libs/gui/widgets/WatchlistDock.hpp
+++ b/libs/gui/widgets/WatchlistDock.hpp
@@ -2,6 +2,10 @@
 #include "DockablePanel.hpp"
 #include <QTreeView>
 #include <QStandardItemModel>
+#include <QComboBox>
+#include <QString>
+#include <QVector>
+#include <QPair>
 
 class WatchlistDock : public DockablePanel {
     Q_OBJECT
@@ -9,10 +13,28 @@ public:
     explicit WatchlistDock(QWidget* parent = nullptr);
     QSize minimumSizeHint() const override;
 
-private:
-    void buildUi() override;
-    void populatePlaceholderData();
+signals:
+    // Emitted when the user clicks a watchlist row.
+    // assetType is "crypto" or "stock" — callers route accordingly.
+    void symbolSelected(const QString& symbol, const QString& assetType);
 
-    QTreeView* m_tree = nullptr;
-    QStandardItemModel* m_model = nullptr;
+private slots:
+    void onPresetChanged(int index);
+    void onRowClicked(const QModelIndex& index);
+
+private:
+    struct WatchlistPreset {
+        QString name;
+        QString assetType;           // "stock" or "crypto"
+        QVector<QPair<QString, QString>> symbols; // (ticker, description)
+    };
+
+    void buildUi() override;
+    void initPresets();
+    void loadPreset(int index);
+
+    QComboBox*          m_presetCombo = nullptr;
+    QTreeView*          m_tree        = nullptr;
+    QStandardItemModel* m_model       = nullptr;
+    QVector<WatchlistPreset> m_presets;
 };

--- a/libs/gui/widgets/WatchlistDock.hpp
+++ b/libs/gui/widgets/WatchlistDock.hpp
@@ -10,6 +10,18 @@
 class WatchlistDock : public DockablePanel {
     Q_OBJECT
 public:
+    // Named roles for QStandardItem custom data — replaces magic Qt::UserRole + N numbers.
+    enum WatchlistItemRole {
+        IsSectionRole = Qt::UserRole + 1,
+        TickerRole,
+        AssetTypeRole,
+    };
+
+    // Strongly-typed asset class — prevents typo-prone "crypto"/"stock" string comparisons
+    // inside WatchlistDock. The public signal still uses QString for interface consistency
+    // with ScreenerDock::rowSelected so callers share a single routing slot.
+    enum class AssetType { Stock, Crypto };
+
     explicit WatchlistDock(QWidget* parent = nullptr);
     QSize minimumSizeHint() const override;
 
@@ -24,10 +36,14 @@ private slots:
 
 private:
     struct WatchlistPreset {
-        QString name;
-        QString assetType;           // "stock" or "crypto"
+        QString    name;
+        AssetType  assetType;
         QVector<QPair<QString, QString>> symbols; // (ticker, description)
     };
+
+    static QString assetTypeString(AssetType t) {
+        return (t == AssetType::Crypto) ? QStringLiteral("crypto") : QStringLiteral("stock");
+    }
 
     void buildUi() override;
     void initPresets();


### PR DESCRIPTION
Replaces the placeholder WatchlistDock with a full preset system:

Presets (selectable via dropdown in the widget header):
  - Major Indices  — SPY, QQQ, DIA, IWM, MDY, VTI, VEA, VWO, EFA, EEM
  - XL Sectors     — all 11 SPDR Select Sector ETFs (XLK through XLC)
  - Commodities    — GLD, SLV, USO, UNG, CORN, WEAT, SOYB, CPER, PALL, PPLT, DBA, DJP
  - Top Stocks     — AAPL, NVDA, MSFT, AMZN, GOOGL, META, TSLA, AVGO, JPM, V, and more
  - Fixed Income   — TLT, IEF, SHY, BND, AGG, HYG, LQD, TIP, MBB, VCSH, VCIT
  - Crypto         — BTC-USD, ETH-USD, SOL-USD, XRP-USD, DOGE-USD, and more Coinbase pairs

Routing is automatic based on preset type:
  - Crypto presets  → symbol sent to HeatmapDock (Coinbase orderbook stream)
  - Stock presets   → symbol sent to StockChartDock (yfinance backend)

Each preset shows a colored badge (● CRYPTO in orange, ● STOCKS in green) so the asset class is always clear at a glance.

https://claude.ai/code/session_0172gSkamqHBcyFGqpu3djYc